### PR TITLE
Use RTC Engine peers

### DIFF
--- a/lib/jellyfish/room.ex
+++ b/lib/jellyfish/room.ex
@@ -105,7 +105,7 @@ defmodule Jellyfish.Room do
         options = %{engine_pid: state.engine_pid, network_options: state.network_options}
         peer = Peer.new(peer_type, options)
         state = put_in(state, [:peers, peer.id], peer)
-        :ok = Engine.add_endpoint(state.engine_pid, peer.engine_endpoint, endpoint_id: peer.id)
+        :ok = Engine.add_endpoint(state.engine_pid, peer.engine_endpoint, peer_id: peer.id)
         {{:ok, peer}, state}
       end
 


### PR DESCRIPTION
The long term goal is to implement peers from scratch in Jellyfish itself but this requires some changes in RTC Engine client SDKS (e.g. you cannot add track before being accepted by the Engine).

Therefore, we want to start with peers implementation provided by the Engine and once signaling and basic Jellyfish client SDK are done, we will start refactoring/implementing peers.