### PR TITLE
Websocket API

### DIFF
--- a/docs/jellyfish-ws.yaml
+++ b/docs/jellyfish-ws.yaml
@@ -1,0 +1,95 @@
+asyncapi: '2.6.0'
+
+info:
+  title: Jellyfish Websocket API
+  version: '0.1.0'
+  contact:
+    name: MembraneTeam
+    url: https://membrane.stream/contact
+  description: |
+    Description of Jellyfish Websocket API.
+
+channels:
+  /:
+    publish:
+      operationId: sendMessage
+      message:
+        oneOf:
+          - $ref: '#/components/messages/clientControlMessage'
+          - $ref: '#/components/messages/mediaEvent'
+
+    subscribe:
+      operationId: processMessage
+      message:
+        oneOf:
+          - $ref: '#/components/messages/serverControlMessage'
+          - $ref: '#/components/messages/mediaEvent'
+
+
+components:
+  messages:
+    clientControlMessage:
+      description: Control Message sent from the peer
+      payload:
+        $ref: '#/components/schemas/clientControlMessage'
+
+    serverControlMessage:
+      description: Control message sent from the Jellyfish server
+      payload:
+        $ref: '#/components/schemas/serverControlMessage'
+
+    mediaEvent:
+      description: A membrane_rtc_engine media event
+      payload:
+        $ref: '#/components/schemas/mediaEvent'
+
+  schemas:
+    clientControlMessage:
+      type: object
+      properties:
+        type:
+          const: 'controlMessage'
+        data:
+          oneOf:
+            - $ref: '#/components/schemas/authRequest'
+
+    serverControlMessage:
+      type: object
+      properties:
+        type: 
+          const: 'controlMessage'
+        data:
+          oneOf:
+            - $ref: '#/components/schemas/authenticated'
+            - $ref: '#/components/schemas/unauthenticated'
+
+    authRequest:
+      description: An authentication request sent from the client
+      type: object
+      properties:
+        type:
+          const: 'authRequest'
+        token:
+          type: string
+
+    authenticated:
+      description: Peer has been succesfully authenticated and other messages can be sent
+      type: object
+      properties:
+        type:
+          const: 'authenticated'
+
+    unauthenticated:
+      description: Peer sent a message without authenticating first or the authentication failed
+      type: object
+      properties:
+        type:
+          const: 'unauthenticated'  
+
+    mediaEvent:
+      type: object
+      properties:
+        type:
+          const: 'mediaEvent'
+        data:
+          type: string      


### PR DESCRIPTION
The HTML preview can be generated using asyncapi studio https://studio.asyncapi.com/ .

This is a very basic documentation of our websocket API. Its main purpose is to establish some common ground for how the messages should look like and discuss the API before implementing it.

In near future we will probably switch to using Protobufs, which will generate proper documentation for the messages.