### PR TITLE
Set valid port in URL config, don't enforce https

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -101,7 +101,7 @@ if config_env() == :prod do
   port = String.to_integer(System.get_env("PORT") || "4000")
 
   config :jellyfish, JellyfishWeb.Endpoint,
-    url: [host: host, port: 443, scheme: "https"],
+    url: [host: host, port: port],
     http: [
       # Enable IPv6 and bind on all interfaces.
       # Set it to  {0, 0, 0, 0, 0, 0, 0, 1} for local network only access.


### PR DESCRIPTION
1. The port is set by env var, it should be matched in the URL setting
2. scheme will be inferred from the rest of the config. If not configurable by env vars, the default should be `http`