### PR TITLE
Use room id instead of room pid

### DIFF
--- a/lib/jellyfish/room.ex
+++ b/lib/jellyfish/room.ex
@@ -43,6 +43,7 @@ defmodule Jellyfish.Room do
 
   @is_prod Mix.env() == :prod
 
+  @spec start(max_peers()) :: {:ok, pid(), id()}
   def start(max_peers) do
     id = UUID.uuid4()
     {:ok, pid} = GenServer.start(__MODULE__, [id, max_peers], name: registry_id(id))

--- a/lib/jellyfish_web/controllers/component_controller.ex
+++ b/lib/jellyfish_web/controllers/component_controller.ex
@@ -62,8 +62,8 @@ defmodule JellyfishWeb.ComponentController do
     with component_options <- Map.get(params, "options"),
          {:ok, component_type_string} <- Map.fetch(params, "type"),
          {:ok, component_type} <- Component.parse_type(component_type_string),
-         {:ok, room_pid} <- RoomService.find_room(room_id),
-         {:ok, component} <- Room.add_component(room_pid, component_type, component_options) do
+         {:ok, _room_pid} <- RoomService.find_room(room_id),
+         {:ok, component} <- Room.add_component(room_id, component_type, component_options) do
       conn
       |> put_resp_content_type("application/json")
       |> put_status(:created)
@@ -76,8 +76,8 @@ defmodule JellyfishWeb.ComponentController do
   end
 
   def delete(conn, %{"room_id" => room_id, "id" => id}) do
-    with {:ok, room_pid} <- RoomService.find_room(room_id),
-         :ok <- Room.remove_component(room_pid, id) do
+    with {:ok, _room_pid} <- RoomService.find_room(room_id),
+         :ok <- Room.remove_component(room_id, id) do
       send_resp(conn, :no_content, "")
     else
       {:error, :room_not_found} -> {:error, :not_found, "Room #{room_id} does not exist"}

--- a/lib/jellyfish_web/controllers/peer_controller.ex
+++ b/lib/jellyfish_web/controllers/peer_controller.ex
@@ -60,6 +60,10 @@ defmodule JellyfishWeb.PeerController do
     ]
 
   def create(conn, %{"room_id" => room_id} = params) do
+    # the room may crash between fetching its
+    # pid and adding a new peer to it
+    # in such a case, the controller will fail
+    # and Phoenix will return 500
     with {:ok, peer_type_string} <- Map.fetch(params, "type"),
          {:ok, peer_type} <- Peer.parse_type(peer_type_string),
          {:ok, _room_pid} <- RoomService.find_room(room_id),

--- a/lib/jellyfish_web/controllers/peer_controller.ex
+++ b/lib/jellyfish_web/controllers/peer_controller.ex
@@ -62,8 +62,8 @@ defmodule JellyfishWeb.PeerController do
   def create(conn, %{"room_id" => room_id} = params) do
     with {:ok, peer_type_string} <- Map.fetch(params, "type"),
          {:ok, peer_type} <- Peer.parse_type(peer_type_string),
-         {:ok, room_pid} <- RoomService.find_room(room_id),
-         {:ok, peer} <- Room.add_peer(room_pid, peer_type) do
+         {:ok, _room_pid} <- RoomService.find_room(room_id),
+         {:ok, peer} <- Room.add_peer(room_id, peer_type) do
       assigns = [peer: peer, token: PeerToken.generate(%{peer_id: peer.id, room_id: room_id})]
 
       conn
@@ -86,8 +86,8 @@ defmodule JellyfishWeb.PeerController do
   end
 
   def delete(conn, %{"room_id" => room_id, "id" => id}) do
-    with {:ok, room_pid} <- RoomService.find_room(room_id),
-         :ok <- Room.remove_peer(room_pid, id) do
+    with {:ok, _room_pid} <- RoomService.find_room(room_id),
+         :ok <- Room.remove_peer(room_id, id) do
       send_resp(conn, :no_content, "")
     else
       {:error, :room_not_found} -> {:error, :not_found, "Room #{room_id} does not exist"}

--- a/test/jellyfish_web/socket_test.exs
+++ b/test/jellyfish_web/socket_test.exs
@@ -14,7 +14,7 @@ defmodule JellyfishWeb.SocketTest do
 
     room_conn = post(conn, ~p"/room", maxPeers: 1)
     assert %{"id" => room_id} = json_response(room_conn, :created)["data"]
-    {:ok, room_pid} = RoomService.find_room(room_id)
+    {:ok, _room_pid} = RoomService.find_room(room_id)
 
     conn = post(conn, ~p"/room/#{room_id}/peer", type: "webrtc")
 
@@ -26,7 +26,7 @@ defmodule JellyfishWeb.SocketTest do
 
     {:ok,
      %{
-       room_pid: room_pid,
+       room_id: room_id,
        authenticated?: false,
        token: token
      }}
@@ -87,7 +87,8 @@ defmodule JellyfishWeb.SocketTest do
   describe "receiving messages from client" do
     setup [:authenticate]
 
-    test "when message is valid Media Event", %{room_pid: room_pid, peer_id: peer_id} = state do
+    test "when message is valid Media Event", %{room_id: room_id, peer_id: peer_id} = state do
+      room_pid = RoomService.find_room!(room_id)
       :erlang.trace(room_pid, true, [:receive])
 
       json = Jason.encode!(%{"type" => "mediaEvent", "data" => @data})


### PR DESCRIPTION
This PR unifies API so that we use everywhere room id. I also changed topic names to room id and removed Room.start_link as it was not used. 