### PR TITLE
Don't spawn dummy tasks on socket initialization

### DIFF
--- a/lib/jellyfish_web/peer_socket.ex
+++ b/lib/jellyfish_web/peer_socket.ex
@@ -9,10 +9,7 @@ defmodule JellyfishWeb.PeerSocket do
   @heartbeat_interval 30_000
 
   @impl true
-  def child_spec(_opts) do
-    # No additional processes are spawned, returning child_spec for dummy task
-    %{id: __MODULE__, start: {Task, :start_link, [fn -> :ok end]}, restart: :transient}
-  end
+  def child_spec(_opts), do: :ignore
 
   @impl true
   def connect(state) do

--- a/lib/jellyfish_web/server_socket .ex
+++ b/lib/jellyfish_web/server_socket .ex
@@ -6,10 +6,7 @@ defmodule JellyfishWeb.ServerSocket do
   @heartbeat_interval 30_000
 
   @impl true
-  def child_spec(_opts) do
-    # No additional processes are spawned, returning child_spec for dummy task
-    %{id: __MODULE__, start: {Task, :start_link, [fn -> :ok end]}, restart: :transient}
-  end
+  def child_spec(_opts), do: :ignore
 
   @impl true
   def connect(state) do


### PR DESCRIPTION
According to [docs](https://hexdocs.pm/phoenix/Phoenix.Socket.Transport.html#c:child_spec/1) we can return :ignore from socket's child_spec and avoid spawning dummy tasks