### PR TITLE
Fix docker volume permissions for Linux. Optimize build time.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -96,7 +96,7 @@ WORKDIR /app
 # base path where jellyfish saves its artefacts
 ENV OUTPUT_BASE_PATH=./jellyfish_output
 
-RUN mkdir ${OUTPUT_BASE_PATH}
+RUN mkdir ${OUTPUT_BASE_PATH} && chown jellyfish:jellyfish ${OUTPUT_BASE_PATH}
 
 COPY --from=build /app/_build/prod/rel/jellyfish ./
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,16 +23,64 @@ RUN mix local.hex --force && \
 
 ENV MIX_ENV=prod
 
+# The order of the following commands is important.
+# It ensures that:
+# * any changes in the `lib` directory will only trigger
+# jellyfish compilation
+# * any changes in the `config` directory will
+# trigger both jellyfish and deps compilation
+# but not deps fetching
+# * any changes in the `config/runtime.exs` won't trigger 
+# anything
 COPY mix.exs mix.lock ./
-COPY config config
-COPY lib lib
+RUN mix deps.get --only $MIX_ENV
 
-RUN mix deps.get
+COPY config/config.exs config/${MIX_ENV}.exs config/
 RUN mix deps.compile
 
-RUN mix do compile, release
+COPY lib lib
+RUN mix compile
+
+COPY config/runtime.exs config/
+
+RUN mix release
 
 FROM alpine:3.17 AS app
+
+RUN addgroup -S jellyfish && adduser -S jellyfish -G jellyfish
+
+# We run the whole image as root, fix permissions in
+# the docker-entrypoint.sh and then use gosu to step-down
+# from the root.
+# See redis docker image for the reference
+# https://github.com/docker-library/redis/blob/master/7.0/Dockerfile#L6
+ENV GOSU_VERSION 1.16
+RUN set -eux; \
+	\
+	apk add --no-cache --virtual .gosu-deps \
+		ca-certificates \
+		dpkg \
+		gnupg \
+	; \
+	\
+	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
+	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
+	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
+	\
+# verify the signature
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+	command -v gpgconf && gpgconf --kill all || :; \
+	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
+	\
+# clean up fetch dependencies
+	apk del --no-network .gosu-deps; \
+	\
+	chmod +x /usr/local/bin/gosu; \
+# verify that the binary works
+	gosu --version; \
+	gosu nobody true
 
 RUN \
   apk add --no-cache \
@@ -45,11 +93,15 @@ RUN \
 
 WORKDIR /app
 
-RUN chown nobody:nobody /app
+# base path where jellyfish saves its artefacts
+ENV OUTPUT_BASE_PATH=./jellyfish_output
 
-USER nobody:nobody
+RUN mkdir ${OUTPUT_BASE_PATH}
 
-COPY --from=build --chown=nobody:nobody /app/_build/prod/rel/jellyfish ./
+COPY --from=build /app/_build/prod/rel/jellyfish ./
+
+COPY docker-entrypoint.sh ./docker-entrypoint.sh
+RUN chmod +x docker-entrypoint.sh
 
 ENV HOME=/app
 
@@ -57,5 +109,6 @@ EXPOSE 4000
 
 HEALTHCHECK CMD curl --fail http://localhost:4000 || exit 1
 
-CMD ["bin/jellyfish", "start"]
+ENTRYPOINT ["./docker-entrypoint.sh"]
 
+CMD ["bin/jellyfish", "start"]

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -72,7 +72,8 @@ config :jellyfish,
   integrated_turn_cert: System.get_env("INTEGRATED_TURN_CERT"),
   integrated_turn_domain: System.get_env("VIRTUAL_HOST"),
   auth_salt: System.get_env("AUTH_SALT", "7d8ecfca-aeaf-43b1-81fa-5eb6d4b0557a"),
-  jwt_max_age: 24 * 3600
+  jwt_max_age: 24 * 3600,
+  output_base_path: System.get_env("OUTPUT_BASE_PATH", "jellyfish_output") |> Path.expand()
 
 config :opentelemetry, traces_exporter: :none
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+log_debug() {
+    if [ "$DOCKER_DEBUG" = 'true' ]; then
+        echo -e $1
+    fi
+}
+
+# root has always UID 0 no matter if we are in docker
+# or on the host
+if [ "$(id -u)" = '0' ]; then
+
+    log_debug "Running as root. Fixing permissions for: \ 
+    $(find . \! -user jellyfish -exec echo '{} \n' \;)"
+        
+    find . \! -user jellyfish -exec chown jellyfish '{}' +
+    exec gosu jellyfish "$0" "$@"
+fi
+
+log_debug "Running as user with UID: $(id -u) GID: $(id -g)"
+
+exec "$@"

--- a/lib/jellyfish/component/hls.ex
+++ b/lib/jellyfish/component/hls.ex
@@ -10,11 +10,14 @@ defmodule Jellyfish.Component.HLS do
 
   @impl true
   def config(options) do
+    base_path = Application.fetch_env!(:jellyfish, :output_base_path)
+    output_dir = Path.join([base_path, "hls_output", "#{options.room_id}"])
+
     {:ok,
      %HLS{
        rtc_engine: options.engine_pid,
        owner: self(),
-       output_directory: "output/#{options.room_id}",
+       output_directory: output_dir,
        mixer_config: nil,
        hls_config: %HLSConfig{}
      }}


### PR DESCRIPTION
This PR fixes docker volume permissions for Linux. In particualr, it should be possible to:
* run docker image as root  with anonymous volume and directory created on the host side at first 
```fish
mkdir out

docker run -p 20000:20000/udp \
-p 4000:4000/tcp \
-e SERVER_API_TOKEN=development \
-e VIRTUAL_HOST=localhost \
-e SECRET_KEY_BASE=secret \
-v $(pwd)/out:/app/jellyfish_output \
jellyfish-my-dev
```
* run docker image as root  with anonymous volume but without directory on the host side
```fish
docker run -p 20000:20000/udp \
-p 4000:4000/tcp \
-e SERVER_API_TOKEN=development \
-e VIRTUAL_HOST=localhost \
-e SECRET_KEY_BASE=secret \
-v $(pwd)/out:/app/jellyfish_output \
jellyfish-my-dev
```
* run docker image as non-root with anonymous volume with directory created on the host side at first
```fish
mkdir out

docker run -p 20000:20000/udp \
-p 4000:4000/tcp \
-u (id -u):(id -g) \
-e SERVER_API_TOKEN=development \
-e VIRTUAL_HOST=localhost \
-e SECRET_KEY_BASE=secret \
-e DOCKER_DEBUG=true \
-v $(pwd)/out:/app/jellyfish_output \
jellyfish-my-dev
```
* run docker image as root with named volume
```fish
docker volume create jellyfish_out

docker run -p 20000:20000/udp \
-p 4000:4000/tcp \
-e SERVER_API_TOKEN=development \
-e VIRTUAL_HOST=localhost \
-e SECRET_KEY_BASE=secret \
-v jellyfish_out:/app/jellyfish_output \
jellyfish-my-dev
```

* run docker image as non-root (jellyfish) with named volume
```fish
docker volume create jellyfish_out

docker run -p 20000:20000/udp \
-p 4000:4000/tcp \
-e SERVER_API_TOKEN=development \
-u jellyfish:jellyfish \
-e VIRTUAL_HOST=localhost \
-e SECRET_KEY_BASE=secret \
-v jellyfish_out:/app/jellyfish_output \
jellyfish-my-dev
```

We won't be able to run the following scenarios
* non-root user and no directory on the host side at first (seems to work on MacOS)
```fish
docker run -p 20000:20000/udp \
-p 4000:4000/tcp \
-u (id -u):(id -g) \
-e SERVER_API_TOKEN=development \
-e VIRTUAL_HOST=localhost \
-e SECRET_KEY_BASE=secret \
-v (pwd)/jellyfish_out:/app/jellyfish_output \
jellyfish-my-dev
```                                                         
* non-root user and named volume
```fish
docker volume create jellyfish_out

docker run -p 20000:20000/udp \
-p 4000:4000/tcp \
-u (id -u):(id -g) \
-e SERVER_API_TOKEN=development \
-e VIRTUAL_HOST=localhost \
-e SECRET_KEY_BASE=secret \
-v jellyfish_out:/app/jellyfish_output \
jellyfish-my-dev
```                                                         
* non-root user and no volume at all
```fish
docker run -p 20000:20000/udp \
-p 4000:4000/tcp \
-u (id -u):(id -g) \
-e SERVER_API_TOKEN=development \
-e VIRTUAL_HOST=localhost \
-e SECRET_KEY_BASE=secret \
-e DOCKER_DEBUG=true \
jellyfish-my-dev
```              