### PR TITLE
Secret key base config

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -82,7 +82,6 @@ config :jellyfish,
   integrated_turn_pkey: System.get_env("INTEGRATED_TURN_PKEY"),
   integrated_turn_cert: System.get_env("INTEGRATED_TURN_CERT"),
   integrated_turn_domain: System.get_env("VIRTUAL_HOST"),
-  auth_salt: System.get_env("AUTH_SALT", "7d8ecfca-aeaf-43b1-81fa-5eb6d4b0557a"),
   jwt_max_age: 24 * 3600,
   output_base_path: System.get_env("OUTPUT_BASE_PATH", "jellyfish_output") |> Path.expand()
 

--- a/docs/jellyfish-ws.yaml
+++ b/docs/jellyfish-ws.yaml
@@ -2,7 +2,7 @@ asyncapi: '2.6.0'
 
 info:
   title: Jellyfish Websocket API
-  version: '0.1.0'
+  version: '0.2.0'
   contact:
     name: MembraneTeam
     url: https://membrane.stream/contact

--- a/lib/jellyfish_web/peer_token.ex
+++ b/lib/jellyfish_web/peer_token.ex
@@ -5,7 +5,7 @@ defmodule JellyfishWeb.PeerToken do
   def generate(data) do
     Phoenix.Token.sign(
       JellyfishWeb.Endpoint,
-      Application.fetch_env!(:jellyfish, :auth_salt),
+      Application.fetch_env!(:jellyfish, JellyfishWeb.Endpoint)[:secret_key_base],
       data
     )
   end
@@ -14,9 +14,9 @@ defmodule JellyfishWeb.PeerToken do
   def verify(token) do
     Phoenix.Token.verify(
       JellyfishWeb.Endpoint,
-      Application.get_env(:jellyfish, :auth_salt),
+      Application.fetch_env!(:jellyfish, JellyfishWeb.Endpoint)[:secret_key_base],
       token,
-      max_age: Application.get_env(:jellyfish, :jwt_max_age)
+      max_age: Application.fetch_env!(:jellyfish, :jwt_max_age)
     )
   end
 end

--- a/lib/jellyfish_web/peer_token.ex
+++ b/lib/jellyfish_web/peer_token.ex
@@ -1,11 +1,12 @@
 defmodule JellyfishWeb.PeerToken do
   @moduledoc false
+  alias JellyfishWeb.Endpoint
 
   @spec generate(map()) :: nonempty_binary
   def generate(data) do
     Phoenix.Token.sign(
-      JellyfishWeb.Endpoint,
-      Application.fetch_env!(:jellyfish, JellyfishWeb.Endpoint)[:secret_key_base],
+      Endpoint,
+      Application.fetch_env!(:jellyfish, Endpoint)[:secret_key_base],
       data
     )
   end
@@ -13,8 +14,8 @@ defmodule JellyfishWeb.PeerToken do
   @spec verify(binary) :: {:ok, any} | {:error, :expired | :invalid | :missing}
   def verify(token) do
     Phoenix.Token.verify(
-      JellyfishWeb.Endpoint,
-      Application.fetch_env!(:jellyfish, JellyfishWeb.Endpoint)[:secret_key_base],
+      Endpoint,
+      Application.fetch_env!(:jellyfish, Endpoint)[:secret_key_base],
       token,
       max_age: Application.fetch_env!(:jellyfish, :jwt_max_age)
     )

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Jellyfish.MixProject do
   def project do
     [
       app: :jellyfish,
-      version: "0.1.0",
+      version: "0.2.0",
       elixir: "~> 1.14",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/jellyfish_web/controllers/peer_controller_test.exs
+++ b/test/jellyfish_web/controllers/peer_controller_test.exs
@@ -46,7 +46,7 @@ defmodule JellyfishWeb.PeerControllerTest do
       assert {:ok, %{peer_id: ^peer_id, room_id: ^room_id}} =
                Phoenix.Token.verify(
                  JellyfishWeb.Endpoint,
-                 Application.get_env(:jellyfish, :auth_salt),
+                 Application.fetch_env!(:jellyfish, JellyfishWeb.Endpoint)[:secret_key_base],
                  token
                )
     end


### PR DESCRIPTION
Removed `AUTH_SALT` env variable, replacing it with so far unused `SECRET_KEY_BASE` variable.