### PR TITLE
[RTC-232] Move peer messages to protobuffs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
 [submodule "protos"]
 	path = protos
 	url = https://github.com/jellyfish-dev/protos.git
-  branch = master
+	branch = master
 	

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
 [submodule "protos"]
 	path = protos
 	url = https://github.com/jellyfish-dev/protos.git
-  branch = peer-notifications
+  branch = master
 	

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
 [submodule "protos"]
 	path = protos
 	url = https://github.com/jellyfish-dev/protos.git
-    branch = master
+  branch = peer-notifications
 	

--- a/lib/jellyfish/room.ex
+++ b/lib/jellyfish/room.ex
@@ -96,8 +96,8 @@ defmodule Jellyfish.Room do
     GenServer.call(registry_id(room_id), {:remove_component, component_id})
   end
 
-  @spec pass_media_event(id(), Peer.id(), String.t()) :: :ok
-  def pass_media_event(room_id, peer_id, event) do
+  @spec receive_media_event(id(), Peer.id(), String.t()) :: :ok
+  def receive_media_event(room_id, peer_id, event) do
     GenServer.cast(registry_id(room_id), {:media_event, peer_id, event})
   end
 

--- a/lib/jellyfish_web/peer_socket.ex
+++ b/lib/jellyfish_web/peer_socket.ex
@@ -80,11 +80,11 @@ defmodule JellyfishWeb.PeerSocket do
   def handle_in({encoded_message, [opcode: :binary]}, state) do
     case PeerMessage.decode(encoded_message) do
       %PeerMessage{content: {:media_event, %MediaEvent{data: data}}} ->
-        Room.pass_media_event(state.room_id, state.peer_id, data)
+        Room.receive_media_event(state.room_id, state.peer_id, data)
 
-      _other ->
+      other ->
         Logger.warn("""
-        Received unexpected message from #{inspect(state.peer_id)}, \
+        Received unexpected message #{other} from #{inspect(state.peer_id)}, \
         room: #{inspect(state.room_id)}
         """)
     end
@@ -92,9 +92,9 @@ defmodule JellyfishWeb.PeerSocket do
     {:ok, state}
   end
 
-  def handle_in({_msg, [opcode: :text]}, state) do
+  def handle_in({msg, [opcode: :text]}, state) do
     Logger.warn("""
-    Received unexpected text message from #{inspect(state.peer_id)}, \
+    Received unexpected text message #{msg} from #{inspect(state.peer_id)}, \
     room: #{inspect(state.room_id)}
     """)
 

--- a/lib/jellyfish_web/peer_socket.ex
+++ b/lib/jellyfish_web/peer_socket.ex
@@ -3,10 +3,10 @@ defmodule JellyfishWeb.PeerSocket do
   @behaviour Phoenix.Socket.Transport
   require Logger
 
-  alias Jellyfish.{Room, RoomService}
-  alias JellyfishWeb.PeerToken
   alias Jellyfish.Peer.ControlMessage
   alias Jellyfish.Peer.ControlMessage.{Authenticated, AuthRequest, MediaEvent}
+  alias Jellyfish.{Room, RoomService}
+  alias JellyfishWeb.PeerToken
 
   @heartbeat_interval 30_000
 

--- a/lib/jellyfish_web/peer_socket.ex
+++ b/lib/jellyfish_web/peer_socket.ex
@@ -76,6 +76,7 @@ defmodule JellyfishWeb.PeerSocket do
     end
   end
 
+  @impl true
   def handle_in({encoded_message, [opcode: :binary]}, state) do
     case PeerMessage.decode(encoded_message) do
       %PeerMessage{content: {:media_event, %MediaEvent{data: data}}} ->
@@ -87,6 +88,15 @@ defmodule JellyfishWeb.PeerSocket do
         room: #{inspect(state.room_id)}
         """)
     end
+
+    {:ok, state}
+  end
+
+  def handle_in({_msg, [opcode: :text]}, state) do
+    Logger.warn("""
+    Received unexpected text message from #{inspect(state.peer_id)}, \
+    room: #{inspect(state.room_id)}
+    """)
 
     {:ok, state}
   end

--- a/lib/jellyfish_web/peer_socket.ex
+++ b/lib/jellyfish_web/peer_socket.ex
@@ -84,7 +84,7 @@ defmodule JellyfishWeb.PeerSocket do
 
       other ->
         Logger.warn("""
-        Received unexpected message #{other} from #{inspect(state.peer_id)}, \
+        Received unexpected message #{inspect(other)} from #{inspect(state.peer_id)}, \
         room: #{inspect(state.room_id)}
         """)
     end

--- a/lib/jellyfish_web/server_socket.ex
+++ b/lib/jellyfish_web/server_socket.ex
@@ -73,7 +73,7 @@ defmodule JellyfishWeb.ServerSocket do
     end
   end
 
-  def handle_in({encoded_message, [opcode: :binary]}, state) do
+  def handle_in({encoded_message, [opcode: _type]}, state) do
     Logger.warn("""
     Received message on server WS.
     Server WS doesn't expect to receive any messages.

--- a/lib/protos/jellyfish/peer_notifications.pb.ex
+++ b/lib/protos/jellyfish/peer_notifications.pb.ex
@@ -1,10 +1,10 @@
-defmodule Jellyfish.Peer.ControlMessage.Authenticated do
+defmodule Jellyfish.PeerMessage.Authenticated do
   @moduledoc false
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 end
 
-defmodule Jellyfish.Peer.ControlMessage.AuthRequest do
+defmodule Jellyfish.PeerMessage.AuthRequest do
   @moduledoc false
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
@@ -12,7 +12,7 @@ defmodule Jellyfish.Peer.ControlMessage.AuthRequest do
   field :token, 1, type: :string
 end
 
-defmodule Jellyfish.Peer.ControlMessage.MediaEvent do
+defmodule Jellyfish.PeerMessage.MediaEvent do
   @moduledoc false
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
@@ -20,22 +20,19 @@ defmodule Jellyfish.Peer.ControlMessage.MediaEvent do
   field :data, 1, type: :string
 end
 
-defmodule Jellyfish.Peer.ControlMessage do
+defmodule Jellyfish.PeerMessage do
   @moduledoc false
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 
   oneof :content, 0
 
-  field :authenticated, 1, type: Jellyfish.Peer.ControlMessage.Authenticated, oneof: 0
+  field :authenticated, 1, type: Jellyfish.PeerMessage.Authenticated, oneof: 0
 
   field :auth_request, 2,
-    type: Jellyfish.Peer.ControlMessage.AuthRequest,
+    type: Jellyfish.PeerMessage.AuthRequest,
     json_name: "authRequest",
     oneof: 0
 
-  field :media_event, 3,
-    type: Jellyfish.Peer.ControlMessage.MediaEvent,
-    json_name: "mediaEvent",
-    oneof: 0
+  field :media_event, 3, type: Jellyfish.PeerMessage.MediaEvent, json_name: "mediaEvent", oneof: 0
 end

--- a/lib/protos/jellyfish/peer_notifications.pb.ex
+++ b/lib/protos/jellyfish/peer_notifications.pb.ex
@@ -1,0 +1,41 @@
+defmodule Jellyfish.Peer.ControlMessage.Authenticated do
+  @moduledoc false
+
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+end
+
+defmodule Jellyfish.Peer.ControlMessage.AuthRequest do
+  @moduledoc false
+
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+
+  field :token, 1, type: :string
+end
+
+defmodule Jellyfish.Peer.ControlMessage.MediaEvent do
+  @moduledoc false
+
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+
+  field :data, 1, type: :string
+end
+
+defmodule Jellyfish.Peer.ControlMessage do
+  @moduledoc false
+
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+
+  oneof :content, 0
+
+  field :authenticated, 1, type: Jellyfish.Peer.ControlMessage.Authenticated, oneof: 0
+
+  field :auth_request, 2,
+    type: Jellyfish.Peer.ControlMessage.AuthRequest,
+    json_name: "authRequest",
+    oneof: 0
+
+  field :media_event, 3,
+    type: Jellyfish.Peer.ControlMessage.MediaEvent,
+    json_name: "mediaEvent",
+    oneof: 0
+end

--- a/lib/protos/jellyfish/server_notifications.pb.ex
+++ b/lib/protos/jellyfish/server_notifications.pb.ex
@@ -1,4 +1,4 @@
-defmodule Jellyfish.Server.ControlMessage.RoomCrashed do
+defmodule Jellyfish.ServerMessage.RoomCrashed do
   @moduledoc false
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
@@ -6,16 +6,7 @@ defmodule Jellyfish.Server.ControlMessage.RoomCrashed do
   field :room_id, 1, type: :string, json_name: "roomId"
 end
 
-defmodule Jellyfish.Server.ControlMessage.PeerConnected do
-  @moduledoc false
-
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
-
-  field :room_id, 1, type: :string, json_name: "roomId"
-  field :peer_id, 2, type: :string, json_name: "peerId"
-end
-
-defmodule Jellyfish.Server.ControlMessage.PeerDisconnected do
+defmodule Jellyfish.ServerMessage.PeerConnected do
   @moduledoc false
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
@@ -24,7 +15,7 @@ defmodule Jellyfish.Server.ControlMessage.PeerDisconnected do
   field :peer_id, 2, type: :string, json_name: "peerId"
 end
 
-defmodule Jellyfish.Server.ControlMessage.PeerCrashed do
+defmodule Jellyfish.ServerMessage.PeerDisconnected do
   @moduledoc false
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
@@ -33,7 +24,16 @@ defmodule Jellyfish.Server.ControlMessage.PeerCrashed do
   field :peer_id, 2, type: :string, json_name: "peerId"
 end
 
-defmodule Jellyfish.Server.ControlMessage.ComponentCrashed do
+defmodule Jellyfish.ServerMessage.PeerCrashed do
+  @moduledoc false
+
+  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
+
+  field :room_id, 1, type: :string, json_name: "roomId"
+  field :peer_id, 2, type: :string, json_name: "peerId"
+end
+
+defmodule Jellyfish.ServerMessage.ComponentCrashed do
   @moduledoc false
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
@@ -42,13 +42,13 @@ defmodule Jellyfish.Server.ControlMessage.ComponentCrashed do
   field :component_id, 2, type: :string, json_name: "componentId"
 end
 
-defmodule Jellyfish.Server.ControlMessage.Authenticated do
+defmodule Jellyfish.ServerMessage.Authenticated do
   @moduledoc false
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
 end
 
-defmodule Jellyfish.Server.ControlMessage.AuthRequest do
+defmodule Jellyfish.ServerMessage.AuthRequest do
   @moduledoc false
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
@@ -56,7 +56,7 @@ defmodule Jellyfish.Server.ControlMessage.AuthRequest do
   field :token, 1, type: :string
 end
 
-defmodule Jellyfish.Server.ControlMessage do
+defmodule Jellyfish.ServerMessage do
   @moduledoc false
 
   use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
@@ -64,34 +64,34 @@ defmodule Jellyfish.Server.ControlMessage do
   oneof :content, 0
 
   field :room_crashed, 1,
-    type: Jellyfish.Server.ControlMessage.RoomCrashed,
+    type: Jellyfish.ServerMessage.RoomCrashed,
     json_name: "roomCrashed",
     oneof: 0
 
   field :peer_connected, 2,
-    type: Jellyfish.Server.ControlMessage.PeerConnected,
+    type: Jellyfish.ServerMessage.PeerConnected,
     json_name: "peerConnected",
     oneof: 0
 
   field :peer_disconnected, 3,
-    type: Jellyfish.Server.ControlMessage.PeerDisconnected,
+    type: Jellyfish.ServerMessage.PeerDisconnected,
     json_name: "peerDisconnected",
     oneof: 0
 
   field :peer_crashed, 4,
-    type: Jellyfish.Server.ControlMessage.PeerCrashed,
+    type: Jellyfish.ServerMessage.PeerCrashed,
     json_name: "peerCrashed",
     oneof: 0
 
   field :component_crashed, 5,
-    type: Jellyfish.Server.ControlMessage.ComponentCrashed,
+    type: Jellyfish.ServerMessage.ComponentCrashed,
     json_name: "componentCrashed",
     oneof: 0
 
-  field :authenticated, 6, type: Jellyfish.Server.ControlMessage.Authenticated, oneof: 0
+  field :authenticated, 6, type: Jellyfish.ServerMessage.Authenticated, oneof: 0
 
   field :auth_request, 7,
-    type: Jellyfish.Server.ControlMessage.AuthRequest,
+    type: Jellyfish.ServerMessage.AuthRequest,
     json_name: "authRequest",
     oneof: 0
 end

--- a/test/jellyfish_web/integration/server_socket_test.exs
+++ b/test/jellyfish_web/integration/server_socket_test.exs
@@ -59,7 +59,7 @@ defmodule JellyfishWeb.Integration.ServerSocketTest do
     assert_receive {:disconnected, {:remote, 1000, "invalid token"}}, 1000
   end
 
-  test "disconnecte when first message is not auth" do
+  test "invalid first message" do
     {:ok, ws} = WS.start_link(@path, :server)
     msg = ServerMessage.encode(%ServerMessage{content: {:authenticated, %Authenticated{}}})
 

--- a/test/jellyfish_web/integration/server_socket_test.exs
+++ b/test/jellyfish_web/integration/server_socket_test.exs
@@ -59,6 +59,14 @@ defmodule JellyfishWeb.Integration.ServerSocketTest do
     assert_receive {:disconnected, {:remote, 1000, "invalid token"}}, 1000
   end
 
+  test "disconnecte when first message is not auth" do
+    {:ok, ws} = WS.start_link(@path, :server)
+    msg = ServerMessage.encode(%ServerMessage{content: {:authenticated, %Authenticated{}}})
+
+    :ok = WS.send_binary_frame(ws, msg)
+    assert_receive {:disconnected, {:remote, 1000, "invalid auth request"}}, 1000
+  end
+
   test "correct token" do
     create_and_authenticate()
   end


### PR DESCRIPTION
Additionally:
- update Protobuf messages names in general (to `PeerMessage` and `ServerMessage`)
- created `handle_cast` to pass media events in `Room` instead of normal message handling