### PR TITLE
Improve outdated `HEALTHCHECK` in `Dockerfile`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -105,6 +105,8 @@ RUN chmod +x docker-entrypoint.sh
 
 ENV HOME=/app
 
+HEALTHCHECK CMD curl --fail -H "authorization: Bearer ${SERVER_API_TOKEN}" http://localhost:${PORT}/room || exit 1
+
 ENTRYPOINT ["./docker-entrypoint.sh"]
 
 CMD ["bin/jellyfish", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -105,10 +105,6 @@ RUN chmod +x docker-entrypoint.sh
 
 ENV HOME=/app
 
-EXPOSE 4000
-
-HEALTHCHECK CMD curl --fail http://localhost:4000 || exit 1
-
 ENTRYPOINT ["./docker-entrypoint.sh"]
 
 CMD ["bin/jellyfish", "start"]

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -79,18 +79,18 @@ unless Enum.empty?(hosts) do
     ]
 end
 
-is_prod? = config_env() == :prod
+prod? = config_env() == :prod
 
 host =
   case System.get_env("VIRTUAL_HOST") do
-    nil when is_prod? -> raise "Unset VIRTUAL_HOST environment variable"
+    nil when prod? -> raise "Unset VIRTUAL_HOST environment variable"
     nil -> "example.com"
     other -> other
   end
 
 port =
   case System.get_env("PORT") do
-    nil when is_prod? -> raise "Unset PORT environment variable"
+    nil when prod? -> raise "Unset PORT environment variable"
     nil -> 4000
     other -> String.to_integer(other)
   end
@@ -114,7 +114,7 @@ config :jellyfish,
 
 config :opentelemetry, traces_exporter: :none
 
-if is_prod? do
+if prod? do
   token =
     System.fetch_env!("SERVER_API_TOKEN") ||
       raise """

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,18 +11,6 @@ x-jellyfish-template: &jellyfish-template
   networks:
     - net1
   restart: on-failure
-  healthcheck:
-    test:
-      [
-        "CMD",
-        "sh",
-        "-c",
-        "curl --fail -H \"authorization: Bearer $$SERVER_API_TOKEN\" http://localhost:$$PORT/room || exit 1"
-      ]
-    interval: 3s
-    retries: 2
-    timeout: 2s
-    start_period: 15s
 
 services:
   test:


### PR DESCRIPTION
`Dockerfile` contains outdated `HEALTHCHECK` (that calls non-existent endpoint) and `EXPOSE` instructions. This PR replaces them.