### PR TITLE
Implement hls storage

### DIFF
--- a/lib/jellyfish/application.ex
+++ b/lib/jellyfish/application.ex
@@ -26,7 +26,6 @@ defmodule Jellyfish.Application do
     ]
 
     :ets.new(:rooms_to_tables, [:public, :set, :named_table])
-    :ets.insert(:rooms_to_tables, {:free_tables, []})
 
     children =
       if topologies == [] do

--- a/lib/jellyfish/application.ex
+++ b/lib/jellyfish/application.ex
@@ -20,9 +20,13 @@ defmodule Jellyfish.Application do
       # Start the RoomService
       Jellyfish.RoomService,
       {Registry, keys: :unique, name: Jellyfish.RoomRegistry},
+      {Registry, keys: :unique, name: Jellyfish.RequestHandlerRegistry},
       # Start the Telemetry supervisor (must be started after Jellyfish.RoomRegistry)
       JellyfishWeb.Telemetry
     ]
+
+    :ets.new(:rooms_to_tables, [:public, :set, :named_table])
+    :ets.insert(:rooms_to_tables, {:free_tables, []})
 
     children =
       if topologies == [] do

--- a/lib/jellyfish/component/hls.ex
+++ b/lib/jellyfish/component/hls.ex
@@ -6,7 +6,7 @@ defmodule Jellyfish.Component.HLS do
   @behaviour Jellyfish.Endpoint.Config
   @behaviour Jellyfish.Component
 
-  alias Jellyfish.Component.HLS.Storage
+  alias Jellyfish.Component.HLS.{LLStorage, RequestHandler}
   alias Membrane.RTC.Engine.Endpoint.HLS
   alias Membrane.RTC.Engine.Endpoint.HLS.{CompositorConfig, HLSConfig, MixerConfig}
   alias Membrane.Time
@@ -20,6 +20,9 @@ defmodule Jellyfish.Component.HLS do
   def config(options) do
     base_path = Application.fetch_env!(:jellyfish, :output_base_path)
     output_dir = Path.join([base_path, "hls_output", "#{options.room_id}"])
+
+    storage = fn directory -> %LLStorage{directory: directory, room_id: options.room_id} end
+    RequestHandler.start(%{room_id: options.room_id})
 
     {:ok,
      %HLS{
@@ -43,9 +46,7 @@ defmodule Jellyfish.Component.HLS do
          target_window_duration: :infinity,
          segment_duration: @segment_duration,
          partial_segment_duration: @partial_segment_duration,
-         storage: fn directory ->
-           Storage.init(%{directory: directory, room_id: options.room_id})
-         end
+         storage: storage
        }
      }}
   end

--- a/lib/jellyfish/component/hls.ex
+++ b/lib/jellyfish/component/hls.ex
@@ -13,8 +13,8 @@ defmodule Jellyfish.Component.HLS do
   alias Membrane.RTC.Engine.Endpoint.HLS.{CompositorConfig, HLSConfig, MixerConfig}
   alias Membrane.Time
 
-  @segment_duration Time.seconds(4)
-  @partial_segment_duration Time.milliseconds(400)
+  @segment_duration Time.seconds(6)
+  @partial_segment_duration Time.milliseconds(1_100)
 
   @type metadata :: %{playable: boolean()}
 

--- a/lib/jellyfish/component/hls.ex
+++ b/lib/jellyfish/component/hls.ex
@@ -7,6 +7,8 @@ defmodule Jellyfish.Component.HLS do
   @behaviour Jellyfish.Component
 
   alias Jellyfish.Component.HLS.{LLStorage, RequestHandler}
+  alias Jellyfish.Room
+
   alias Membrane.RTC.Engine.Endpoint.HLS
   alias Membrane.RTC.Engine.Endpoint.HLS.{CompositorConfig, HLSConfig, MixerConfig}
   alias Membrane.Time
@@ -18,9 +20,6 @@ defmodule Jellyfish.Component.HLS do
 
   @impl true
   def config(options) do
-    base_path = Application.fetch_env!(:jellyfish, :output_base_path)
-    output_dir = Path.join([base_path, "hls_output", "#{options.room_id}"])
-
     storage = fn directory -> %LLStorage{directory: directory, room_id: options.room_id} end
     RequestHandler.start(%{room_id: options.room_id})
 
@@ -28,7 +27,7 @@ defmodule Jellyfish.Component.HLS do
      %HLS{
        rtc_engine: options.engine_pid,
        owner: self(),
-       output_directory: output_dir,
+       output_directory: output_dir(options.room_id),
        mixer_config: %MixerConfig{
          video: %CompositorConfig{
            stream_format: %Membrane.RawVideo{
@@ -53,4 +52,10 @@ defmodule Jellyfish.Component.HLS do
 
   @impl true
   def metadata(), do: %{playable: false}
+
+  @spec output_dir(Room.id()) :: String.t()
+  def output_dir(room_id) do
+    base_path = Application.fetch_env!(:jellyfish, :output_base_path)
+    Path.join([base_path, "hls_output", "#{room_id}"])
+  end
 end

--- a/lib/jellyfish/component/hls.ex
+++ b/lib/jellyfish/component/hls.ex
@@ -6,6 +6,7 @@ defmodule Jellyfish.Component.HLS do
   @behaviour Jellyfish.Endpoint.Config
   @behaviour Jellyfish.Component
 
+  alias Jellyfish.Component.HLS.Storage
   alias Membrane.RTC.Engine.Endpoint.HLS
   alias Membrane.RTC.Engine.Endpoint.HLS.{CompositorConfig, HLSConfig, MixerConfig}
   alias Membrane.Time
@@ -41,7 +42,10 @@ defmodule Jellyfish.Component.HLS do
          mode: :live,
          target_window_duration: :infinity,
          segment_duration: @segment_duration,
-         partial_segment_duration: @partial_segment_duration
+         partial_segment_duration: @partial_segment_duration,
+         storage: fn directory ->
+           Storage.init(%{directory: directory, room_id: options.room_id})
+         end
        }
      }}
   end

--- a/lib/jellyfish/component/hls.ex
+++ b/lib/jellyfish/component/hls.ex
@@ -21,7 +21,7 @@ defmodule Jellyfish.Component.HLS do
   @impl true
   def config(options) do
     storage = fn directory -> %LLStorage{directory: directory, room_id: options.room_id} end
-    RequestHandler.start(%{room_id: options.room_id})
+    RequestHandler.start(options.room_id)
 
     {:ok,
      %HLS{

--- a/lib/jellyfish/component/hls/ets_helper.ex
+++ b/lib/jellyfish/component/hls/ets_helper.ex
@@ -6,93 +6,17 @@ defmodule Jellyfish.Component.HLS.EtsHelper do
   @rooms_to_tabels :rooms_to_tables
   @free_tables :free_tables
 
-  @last_partial_key :last_partial
+  @recent_partial_key :recent_partial
   @manifest_key :manifest
 
-  @delta_last_partial_key :delta_last_partial
+  @delta_recent_partial_key :delta_recent_partial
   @delta_manifest_key :delta_manifest
 
   @type partial :: {non_neg_integer(), non_neg_integer()}
 
-  def get_partial(room_id, filename, offset) do
-    table = get_table(room_id)
-    key = generate_partial_key(filename, offset)
-    [{^key, partial}] = :ets.lookup(table, key)
-    {:ok, partial}
-  end
-
-  def get_last_partial(room_id, filename) do
-    table = get_table(room_id)
-
-    [{_key, last_partial}] =
-      if String.contains?(filename, "_delta.m3u8"),
-        do: :ets.lookup(table, @delta_last_partial_key),
-        else: :ets.lookup(table, @last_partial_key)
-
-    last_partial
-  end
-
-  def get_manifest(room_id, filename) do
-    table = get_table(room_id)
-
-    [{_key, manifest}] =
-      if String.contains?(filename, "_delta.m3u8"),
-        do: :ets.lookup(table, @delta_manifest_key),
-        else: :ets.lookup(table, @manifest_key)
-
-    manifest
-  end
-
-  @spec add_last_partial(Room.id(), partial()) :: true
-  def add_last_partial(room_id, last_partial) do
-    table = get_table(room_id)
-    :ets.insert(table, {@last_partial_key, last_partial})
-  end
-
-  @spec add_last_partial(Room.id(), partial()) :: true
-  def add_delta_last_partial(room_id, delta_last_partial) do
-    table = get_table(room_id)
-    :ets.insert(table, {@delta_last_partial_key, delta_last_partial})
-  end
-
-  @spec add_delta_manifest(Room.id(), String.t()) :: true
-  def add_delta_manifest(room_id, delta_manifest) do
-    table = get_table(room_id)
-    :ets.insert(table, {@delta_manifest_key, delta_manifest})
-  end
-
-  @spec add_manifest(Room.id(), String.t()) :: true
-  def add_manifest(room_id, manifest) do
-    table = get_table(room_id)
-    :ets.insert(table, {@manifest_key, manifest})
-  end
-
-  @spec remove_partial(Room.id(), String.t(), non_neg_integer()) :: true
-  def remove_partial(room_id, filename, offset) do
-    table = get_table(room_id)
-    key = generate_partial_key(filename, offset)
-    :ets.delete(table, key)
-  end
-
-  @spec add_partial(Room.id(), binary(), String.t(), non_neg_integer()) :: true
-  def add_partial(room_id, partial, filename, offset) do
-    table = get_table(room_id)
-    key = generate_partial_key(filename, offset)
-    :ets.insert(table, {key, partial})
-  end
-
-  @spec remove_room(Room.id()) :: :ok | {:error, :not_exists}
-  def remove_room(room_id) do
-    case :ets.lookup(@rooms_to_tabels, room_id) do
-      [{^room_id, table}] ->
-        add_to_free_tables(table)
-        :ets.delete(@rooms_to_tabels, room_id)
-        :ok
-
-      _empty ->
-        {:error, :not_exists}
-    end
-  end
+  ###
+  ### ROOM MANAGMENT
+  ###
 
   @spec add_room(Room.id()) :: :ok | {:error, :already_exists}
   def add_room(room_id) do
@@ -109,6 +33,113 @@ defmodule Jellyfish.Component.HLS.EtsHelper do
         table = generate_table()
         add_room(room_id, table)
         :ok
+    end
+  end
+
+  @spec remove_room(Room.id()) :: :ok | {:error, String.t()}
+  def remove_room(room_id) do
+    case :ets.lookup(@rooms_to_tabels, room_id) do
+      [{^room_id, table}] ->
+        add_to_free_tables(table)
+        :ets.delete(table)
+        :ets.delete(@rooms_to_tabels, room_id)
+        :ok
+
+      _empty ->
+        {:error, "Room: #{room_id} doesn't exist"}
+    end
+  end
+
+  ###
+  ### ETS CONTENT MANAGMENT
+  ###
+
+  @spec update_manifest(Room.id(), String.t()) :: true
+  def update_manifest(room_id, manifest) do
+    object = {@manifest_key, manifest}
+    add_to_ets(room_id, object)
+  end
+
+  @spec update_delta_manifest(Room.id(), String.t()) :: true
+  def update_delta_manifest(room_id, delta_manifest) do
+    object = {@delta_manifest_key, delta_manifest}
+    add_to_ets(room_id, object)
+  end
+
+  @spec update_recent_partial(Room.id(), partial()) :: true
+  def update_recent_partial(room_id, partial) do
+    object = {@recent_partial_key, partial}
+    add_to_ets(room_id, object)
+  end
+
+  @spec update_delta_recent_partial(Room.id(), partial()) :: true
+  def update_delta_recent_partial(room_id, partial) do
+    object = {@delta_recent_partial_key, partial}
+    add_to_ets(room_id, object)
+  end
+
+  @spec add_partial(Room.id(), binary(), String.t(), non_neg_integer()) :: true
+  def add_partial(room_id, partial, filename, offset) do
+    key = generate_partial_key(filename, offset)
+    object = {key, partial}
+    add_to_ets(room_id, object)
+  end
+
+  @spec delete_partial(Room.id(), String.t(), non_neg_integer()) :: true
+  def delete_partial(room_id, filename, offset) do
+    table = get_table(room_id)
+    key = generate_partial_key(filename, offset)
+    :ets.delete(table, key)
+  end
+
+  ###
+  ### ETS GETTERS
+  ###
+
+  @spec get_partial(Room.id(), String.t(), non_neg_integer()) ::
+          {:ok, binary()} | {:error, :not_found}
+  def get_partial(room_id, filename, offset) do
+    key = generate_partial_key(filename, offset)
+    get_from_ets(room_id, key)
+  end
+
+  @spec get_recent_partial(Room.id()) ::
+          {:ok, {non_neg_integer(), non_neg_integer()}} | {:error, :not_found}
+  def get_recent_partial(room_id) do
+    get_from_ets(room_id, @recent_partial_key)
+  end
+
+  @spec get_delta_recent_partial(Room.id()) ::
+          {:ok, {non_neg_integer(), non_neg_integer()}} | {:error, :not_found}
+  def get_delta_recent_partial(room_id) do
+    get_from_ets(room_id, @delta_recent_partial_key)
+  end
+
+  @spec get_manifest(Room.id()) :: {:ok, String.t()} | {:error, :not_found}
+  def get_manifest(room_id) do
+    get_from_ets(room_id, @manifest_key)
+  end
+
+  @spec get_delta_manifest(Room.id()) :: {:ok, String.t()} | {:error, :not_found}
+  def get_delta_manifest(room_id) do
+    get_from_ets(room_id, @delta_manifest_key)
+  end
+
+  ###
+  ### PRIVATE FUNCTIONS
+  ###
+
+  defp add_to_ets(room_id, object) do
+    table = get_table(room_id)
+    :ets.insert(table, object)
+  end
+
+  def get_from_ets(room_id, key) do
+    table = get_table(room_id)
+
+    case :ets.lookup(table, key) do
+      [{^key, manifest}] -> {:ok, manifest}
+      [] -> {:error, :not_found}
     end
   end
 

--- a/lib/jellyfish/component/hls/ets_helper.ex
+++ b/lib/jellyfish/component/hls/ets_helper.ex
@@ -4,7 +4,6 @@ defmodule Jellyfish.Component.HLS.EtsHelper do
   alias Jellyfish.Room
 
   @rooms_to_tabels :rooms_to_tables
-  @free_tables :free_tables
 
   @recent_partial_key :recent_partial
   @manifest_key :manifest
@@ -18,21 +17,16 @@ defmodule Jellyfish.Component.HLS.EtsHelper do
   ### ROOM MANAGMENT
   ###
 
-  @spec add_room(Room.id()) :: :ok | {:error, :already_exists}
+  @spec add_room(Room.id()) :: {:ok, reference()} | {:error, :already_exists}
   def add_room(room_id) do
-    cond do
-      room_exists?(room_id) ->
-        {:error, :already_exists}
-
-      free_table_exists?() ->
-        table = get_free_table()
-        add_room(room_id, table)
-        :ok
-
-      true ->
-        table = generate_table()
-        add_room(room_id, table)
-        :ok
+    if room_exists?(room_id) do
+      {:error, :already_exists}
+    else
+      # Ets is public because ll-storage can't delete table.
+      # If we change that storage can be protected
+      table = :ets.new(:hls_storage, [:public])
+      :ets.insert(@rooms_to_tabels, {room_id, table})
+      {:ok, table}
     end
   end
 
@@ -40,7 +34,6 @@ defmodule Jellyfish.Component.HLS.EtsHelper do
   def remove_room(room_id) do
     case :ets.lookup(@rooms_to_tabels, room_id) do
       [{^room_id, table}] ->
-        add_to_free_tables(table)
         :ets.delete(table)
         :ets.delete(@rooms_to_tabels, room_id)
         :ok
@@ -54,40 +47,34 @@ defmodule Jellyfish.Component.HLS.EtsHelper do
   ### ETS CONTENT MANAGMENT
   ###
 
-  @spec update_manifest(Room.id(), String.t()) :: true
-  def update_manifest(room_id, manifest) do
-    object = {@manifest_key, manifest}
-    add_to_ets(room_id, object)
+  @spec update_manifest(:ets.table(), String.t()) :: true
+  def update_manifest(table, manifest) do
+    :ets.insert(table, {@manifest_key, manifest})
   end
 
-  @spec update_delta_manifest(Room.id(), String.t()) :: true
-  def update_delta_manifest(room_id, delta_manifest) do
-    object = {@delta_manifest_key, delta_manifest}
-    add_to_ets(room_id, object)
+  @spec update_delta_manifest(:ets.table(), String.t()) :: true
+  def update_delta_manifest(table, delta_manifest) do
+    :ets.insert(table, {@delta_manifest_key, delta_manifest})
   end
 
-  @spec update_recent_partial(Room.id(), partial()) :: true
-  def update_recent_partial(room_id, partial) do
-    object = {@recent_partial_key, partial}
-    add_to_ets(room_id, object)
+  @spec update_recent_partial(:ets.table(), partial()) :: true
+  def update_recent_partial(table, partial) do
+    :ets.insert(table, {@recent_partial_key, partial})
   end
 
-  @spec update_delta_recent_partial(Room.id(), partial()) :: true
-  def update_delta_recent_partial(room_id, partial) do
-    object = {@delta_recent_partial_key, partial}
-    add_to_ets(room_id, object)
+  @spec update_delta_recent_partial(:ets.table(), partial()) :: true
+  def update_delta_recent_partial(table, partial) do
+    :ets.insert(table, {@delta_recent_partial_key, partial})
   end
 
-  @spec add_partial(Room.id(), binary(), String.t(), non_neg_integer()) :: true
-  def add_partial(room_id, partial, filename, offset) do
+  @spec add_partial(:ets.table(), binary(), String.t(), non_neg_integer()) :: true
+  def add_partial(table, partial, filename, offset) do
     key = generate_partial_key(filename, offset)
-    object = {key, partial}
-    add_to_ets(room_id, object)
+    :ets.insert(table, {key, partial})
   end
 
-  @spec delete_partial(Room.id(), String.t(), non_neg_integer()) :: true
-  def delete_partial(room_id, filename, offset) do
-    table = get_table(room_id)
+  @spec delete_partial(:ets.table(), String.t(), non_neg_integer()) :: true
+  def delete_partial(table, filename, offset) do
     key = generate_partial_key(filename, offset)
     :ets.delete(table, key)
   end
@@ -129,11 +116,6 @@ defmodule Jellyfish.Component.HLS.EtsHelper do
   ### PRIVATE FUNCTIONS
   ###
 
-  defp add_to_ets(room_id, object) do
-    table = get_table(room_id)
-    :ets.insert(table, object)
-  end
-
   def get_from_ets(room_id, key) do
     table = get_table(room_id)
 
@@ -150,42 +132,8 @@ defmodule Jellyfish.Component.HLS.EtsHelper do
     end
   end
 
-  defp add_to_free_tables(table) do
-    [{@free_tables, free_tables}] = :ets.lookup(@rooms_to_tabels, @free_tables)
-    :ets.insert(@rooms_to_tabels, {@free_tables, [table | free_tables]})
-  end
-
   defp room_exists?(room_id) do
-    if :ets.lookup(@rooms_to_tabels, room_id) == [], do: false, else: true
-  end
-
-  defp free_table_exists?() do
-    [{@free_tables, free_tables}] = :ets.lookup(@rooms_to_tabels, @free_tables)
-    if free_tables == [], do: false, else: true
-  end
-
-  defp get_free_table() do
-    [{@free_tables, free_tables}] = :ets.lookup(@rooms_to_tabels, @free_tables)
-    [table | rest] = free_tables
-    :ets.insert(@rooms_to_tabels, {@free_tables, rest})
-    table
-  end
-
-  defp add_room(room_id, table) do
-    :ets.insert(@rooms_to_tabels, {room_id, table})
-    :ets.new(table, [:public, :set, :named_table])
-  end
-
-  defp generate_table() do
-    table = String.to_atom(UUID.uuid1())
-    if table_exists?(table), do: generate_table(), else: table
-  end
-
-  defp table_exists?(table) do
-    @rooms_to_tabels
-    |> :ets.tab2list()
-    |> Enum.all?(fn {_key, value} -> value != table end)
-    |> Kernel.not()
+    :ets.lookup(@rooms_to_tabels, room_id) != []
   end
 
   defp generate_partial_key(filename, offset), do: "#{filename}_#{offset}"

--- a/lib/jellyfish/component/hls/ets_helper.ex
+++ b/lib/jellyfish/component/hls/ets_helper.ex
@@ -34,7 +34,7 @@ defmodule Jellyfish.Component.HLS.EtsHelper do
   def remove_room(room_id) do
     case :ets.lookup(@rooms_to_tables, room_id) do
       [{^room_id, table}] ->
-        :ets.delete(table)
+        if table_exists?(table), do: :ets.delete(table)
         :ets.delete(@rooms_to_tables, room_id)
         :ok
 
@@ -138,6 +138,10 @@ defmodule Jellyfish.Component.HLS.EtsHelper do
 
   defp room_exists?(room_id) do
     :ets.lookup(@rooms_to_tables, room_id) != []
+  end
+
+  defp table_exists?(table) do
+    :ets.info(table) != :undefined
   end
 
   defp generate_partial_key(filename, offset), do: "#{filename}_#{offset}"

--- a/lib/jellyfish/component/hls/ets_helper.ex
+++ b/lib/jellyfish/component/hls/ets_helper.ex
@@ -1,0 +1,161 @@
+defmodule Jellyfish.Component.HLS.EtsHelper do
+  @moduledoc false
+
+  alias Jellyfish.Room
+
+  @rooms_to_tabels :rooms_to_tables
+  @free_tables :free_tables
+
+  @last_partial_key :last_partial
+  @manifest_key :manifest
+
+  @delta_last_partial_key :delta_last_partial
+  @delta_manifest_key :delta_manifest
+
+  @type partial :: {non_neg_integer(), non_neg_integer()}
+
+  def get_partial(room_id, filename, offset) do
+    table = get_table(room_id)
+    key = generate_partial_key(filename, offset)
+    [{^key, partial}] = :ets.lookup(table, key)
+    {:ok, partial}
+  end
+
+  def get_last_partial(room_id, filename) do
+    table = get_table(room_id)
+
+    [{_key, last_partial}] =
+      if String.contains?(filename, "_delta.m3u8"),
+        do: :ets.lookup(table, @delta_last_partial_key),
+        else: :ets.lookup(table, @last_partial_key)
+
+    last_partial
+  end
+
+  def get_manifest(room_id, filename) do
+    table = get_table(room_id)
+
+    [{_key, manifest}] =
+      if String.contains?(filename, "_delta.m3u8"),
+        do: :ets.lookup(table, @delta_manifest_key),
+        else: :ets.lookup(table, @manifest_key)
+
+    manifest
+  end
+
+  @spec add_last_partial(Room.id(), partial()) :: true
+  def add_last_partial(room_id, last_partial) do
+    table = get_table(room_id)
+    :ets.insert(table, {@last_partial_key, last_partial})
+  end
+
+  @spec add_last_partial(Room.id(), partial()) :: true
+  def add_delta_last_partial(room_id, delta_last_partial) do
+    table = get_table(room_id)
+    :ets.insert(table, {@delta_last_partial_key, delta_last_partial})
+  end
+
+  @spec add_delta_manifest(Room.id(), String.t()) :: true
+  def add_delta_manifest(room_id, delta_manifest) do
+    table = get_table(room_id)
+    :ets.insert(table, {@delta_manifest_key, delta_manifest})
+  end
+
+  @spec add_manifest(Room.id(), String.t()) :: true
+  def add_manifest(room_id, manifest) do
+    table = get_table(room_id)
+    :ets.insert(table, {@manifest_key, manifest})
+  end
+
+  @spec remove_partial(Room.id(), String.t(), non_neg_integer()) :: true
+  def remove_partial(room_id, filename, offset) do
+    table = get_table(room_id)
+    key = generate_partial_key(filename, offset)
+    :ets.delete(table, key)
+  end
+
+  @spec add_partial(Room.id(), binary(), String.t(), non_neg_integer()) :: true
+  def add_partial(room_id, partial, filename, offset) do
+    table = get_table(room_id)
+    key = generate_partial_key(filename, offset)
+    :ets.insert(table, {key, partial})
+  end
+
+  @spec remove_room(Room.id()) :: :ok | {:error, :not_exists}
+  def remove_room(room_id) do
+    case :ets.lookup(@rooms_to_tabels, room_id) do
+      [{^room_id, table}] ->
+        add_to_free_tables(table)
+        :ets.delete(@rooms_to_tabels, room_id)
+        :ok
+
+      _empty ->
+        {:error, :not_exists}
+    end
+  end
+
+  @spec add_room(Room.id()) :: :ok | {:error, :already_exists}
+  def add_room(room_id) do
+    cond do
+      room_exists?(room_id) ->
+        {:error, :already_exists}
+
+      free_table_exists?() ->
+        table = get_free_table()
+        add_room(room_id, table)
+        :ok
+
+      true ->
+        table = generate_table()
+        add_room(room_id, table)
+        :ok
+    end
+  end
+
+  defp get_table(room_id) do
+    case :ets.lookup(@rooms_to_tabels, room_id) do
+      [{^room_id, table}] -> table
+      _empty -> {:error, :not_exists}
+    end
+  end
+
+  defp add_to_free_tables(table) do
+    [{@free_tables, free_tables}] = :ets.lookup(@rooms_to_tabels, @free_tables)
+    :ets.insert(@rooms_to_tabels, {@free_tables, [table | free_tables]})
+  end
+
+  defp room_exists?(room_id) do
+    if :ets.lookup(@rooms_to_tabels, room_id) == [], do: false, else: true
+  end
+
+  defp free_table_exists?() do
+    [{@free_tables, free_tables}] = :ets.lookup(@rooms_to_tabels, @free_tables)
+    if free_tables == [], do: false, else: true
+  end
+
+  defp get_free_table() do
+    [{@free_tables, free_tables}] = :ets.lookup(@rooms_to_tabels, @free_tables)
+    [table | rest] = free_tables
+    :ets.insert(@rooms_to_tabels, {@free_tables, rest})
+    table
+  end
+
+  defp add_room(room_id, table) do
+    :ets.insert(@rooms_to_tabels, {room_id, table})
+    :ets.new(table, [:public, :set, :named_table])
+  end
+
+  defp generate_table() do
+    table = String.to_atom(UUID.uuid1())
+    if table_exists?(table), do: generate_table(), else: table
+  end
+
+  defp table_exists?(table) do
+    @rooms_to_tabels
+    |> :ets.tab2list()
+    |> Enum.all?(fn {_key, value} -> value != table end)
+    |> Kernel.not()
+  end
+
+  defp generate_partial_key(filename, offset), do: "#{filename}_#{offset}"
+end

--- a/lib/jellyfish/component/hls/ll_storage.ex
+++ b/lib/jellyfish/component/hls/ll_storage.ex
@@ -25,6 +25,7 @@ defmodule Jellyfish.Component.HLS.LLStorage do
         }
 
   @ets_cached_duration_in_segments 4
+  @delta_manifest_suffix "_delta.m3u8"
 
   @impl true
   def init(%__MODULE__{directory: directory, room_id: room_id}) do
@@ -104,7 +105,7 @@ defmodule Jellyfish.Component.HLS.LLStorage do
   end
 
   defp add_manifest_to_ets(filename, manifest, %{table: table}) do
-    if String.ends_with?(filename, "_delta.m3u8") do
+    if String.ends_with?(filename, @delta_manifest_suffix) do
       EtsHelper.update_delta_manifest(table, manifest)
     else
       EtsHelper.update_manifest(table, manifest)
@@ -149,7 +150,7 @@ defmodule Jellyfish.Component.HLS.LLStorage do
          segment_sn: segment_sn,
          partial_sn: partial_sn
        }) do
-    if String.ends_with?(filename, "_delta.m3u8") do
+    if String.ends_with?(filename, @delta_manifest_suffix) do
       EtsHelper.update_delta_recent_partial(table, {segment_sn, partial_sn})
       RequestHandler.update_delta_recent_partial(room_id, {segment_sn, partial_sn})
     else

--- a/lib/jellyfish/component/hls/ll_storage.ex
+++ b/lib/jellyfish/component/hls/ll_storage.ex
@@ -105,9 +105,9 @@ defmodule Jellyfish.Component.HLS.LLStorage do
 
   defp add_manifest_to_ets(filename, manifest, %{room_id: room_id}) do
     if String.contains?(filename, "_delta.m3u8") do
-      EtsHelper.add_manifest(room_id, manifest)
+      EtsHelper.update_delta_manifest(room_id, manifest)
     else
-      EtsHelper.add_delta_manifest(room_id, manifest)
+      EtsHelper.update_manifest(room_id, manifest)
     end
   end
 
@@ -136,7 +136,7 @@ defmodule Jellyfish.Component.HLS.LLStorage do
     partials_in_ets =
       Enum.filter(partials_in_ets, fn {{segment_sn, _partial_sn}, {filename, offset}} ->
         if segment_sn + @ets_duration_in_segments <= curr_segment_sn do
-          EtsHelper.remove_partial(room_id, filename, offset)
+          EtsHelper.delete_partial(room_id, filename, offset)
           false
         else
           true
@@ -152,11 +152,11 @@ defmodule Jellyfish.Component.HLS.LLStorage do
          partial_sn: partial_sn
        }) do
     if String.contains?(filename, "_delta.m3u8") do
-      EtsHelper.add_delta_last_partial(room_id, {segment_sn, partial_sn})
-      RequestHandler.update_last_partial(room_id, {segment_sn, partial_sn}, :delta)
+      EtsHelper.update_delta_recent_partial(room_id, {segment_sn, partial_sn})
+      RequestHandler.update_delta_recent_partial(room_id, {segment_sn, partial_sn})
     else
-      EtsHelper.add_last_partial(room_id, {segment_sn, partial_sn})
-      RequestHandler.update_last_partial(room_id, {segment_sn, partial_sn}, :regular)
+      EtsHelper.update_recent_partial(room_id, {segment_sn, partial_sn})
+      RequestHandler.update_recent_partial(room_id, {segment_sn, partial_sn})
     end
   end
 

--- a/lib/jellyfish/component/hls/ll_storage.ex
+++ b/lib/jellyfish/component/hls/ll_storage.ex
@@ -1,0 +1,183 @@
+defmodule Jellyfish.Component.HLS.LLStorage do
+  @moduledoc false
+
+  @behaviour Membrane.HTTPAdaptiveStream.Storage
+
+  alias Jellyfish.Component.HLS.{EtsHelper, RequestHandler}
+  alias Jellyfish.Room
+
+  @enforce_keys [:directory, :room_id]
+  defstruct @enforce_keys ++
+              [partial_sn: 0, segment_sn: 0, partials_in_ets: []]
+
+  @type partial_ets_key :: String.t()
+  @type sequence_number :: non_neg_integer()
+  @type partial_in_ets ::
+          {{segment_sn :: sequence_number(), partial_sn :: sequence_number()}, partial_ets_key()}
+
+  @type t :: %__MODULE__{
+          directory: Path.t(),
+          room_id: Room.id(),
+          partial_sn: sequence_number(),
+          segment_sn: sequence_number(),
+          partials_in_ets: [partial_in_ets()]
+        }
+
+  @ets_duration_in_segments 4
+
+  @impl true
+  def init(%__MODULE__{directory: directory, room_id: room_id}) do
+    with :ok <- EtsHelper.add_room(room_id) do
+      %__MODULE__{room_id: room_id, directory: directory}
+    else
+      {:error, :already_exists} -> {:error, :cannot_create_ets_table}
+    end
+  end
+
+  @impl true
+  def store(_parent_id, name, content, metadata, context, state) do
+    case context do
+      %{mode: :binary, type: :segment} ->
+        {:ok, state}
+
+      %{mode: :binary, type: :partial_segment} ->
+        store_partial_segment(name, content, metadata, state)
+
+      %{mode: :binary, type: :header} ->
+        store_header(name, content, state)
+
+      %{mode: :text, type: :manifest} ->
+        store_manifest(name, content, state)
+    end
+  end
+
+  @impl true
+  def remove(_parent_id, name, _ctx, %__MODULE__{directory: directory} = state) do
+    result =
+      directory
+      |> Path.join(name)
+      |> File.rm()
+
+    {result, state}
+  end
+
+  defp store_partial_segment(
+         filename,
+         content,
+         %{byte_offset: offset, sequence_number: sequence_number},
+         %__MODULE__{directory: directory} = state
+       ) do
+    result = write_to_file(directory, filename, content, [:binary, :append])
+
+    state =
+      state
+      |> update_sequence_numbers(sequence_number)
+      |> add_partial_to_ets(filename, offset, content)
+
+    {result, state}
+  end
+
+  defp store_header(
+         filename,
+         content,
+         %__MODULE__{directory: directory} = state
+       ) do
+    result = write_to_file(directory, filename, content, [:binary])
+    {result, state}
+  end
+
+  defp store_manifest(
+         filename,
+         content,
+         %__MODULE__{
+           directory: directory
+         } = state
+       ) do
+    result = write_to_file(directory, filename, content)
+
+    unless filename == "index.m3u8" do
+      add_manifest_to_ets(filename, content, state)
+      send_update(filename, state)
+    end
+
+    {result, state}
+  end
+
+  defp add_manifest_to_ets(filename, manifest, %{room_id: room_id}) do
+    if String.contains?(filename, "_delta.m3u8") do
+      EtsHelper.add_manifest(room_id, manifest)
+    else
+      EtsHelper.add_delta_manifest(room_id, manifest)
+    end
+  end
+
+  defp add_partial_to_ets(
+         %{
+           room_id: room_id,
+           partials_in_ets: partials_in_ets,
+           segment_sn: segment_sn,
+           partial_sn: partial_sn
+         } = state,
+         filename,
+         offset,
+         content
+       ) do
+    EtsHelper.add_partial(room_id, content, filename, offset)
+
+    partial = {segment_sn, partial_sn}
+    %{state | partials_in_ets: [{partial, {filename, offset}} | partials_in_ets]}
+  end
+
+  defp remove_partials_from_ets(
+         %{partials_in_ets: partials_in_ets, segment_sn: curr_segment_sn, room_id: room_id} =
+           state
+       ) do
+    # Remove all partials that are at least @ets_duration_in_segments behind
+    partials_in_ets =
+      Enum.filter(partials_in_ets, fn {{segment_sn, _partial_sn}, {filename, offset}} ->
+        if segment_sn + @ets_duration_in_segments <= curr_segment_sn do
+          EtsHelper.remove_partial(room_id, filename, offset)
+          false
+        else
+          true
+        end
+      end)
+
+    %{state | partials_in_ets: partials_in_ets}
+  end
+
+  defp send_update(filename, %{
+         room_id: room_id,
+         segment_sn: segment_sn,
+         partial_sn: partial_sn
+       }) do
+    if String.contains?(filename, "_delta.m3u8") do
+      EtsHelper.add_delta_last_partial(room_id, {segment_sn, partial_sn})
+      RequestHandler.update_last_partial(room_id, {segment_sn, partial_sn}, :delta)
+    else
+      EtsHelper.add_last_partial(room_id, {segment_sn, partial_sn})
+      RequestHandler.update_last_partial(room_id, {segment_sn, partial_sn}, :regular)
+    end
+  end
+
+  defp update_sequence_numbers(
+         %{segment_sn: segment_sn, partial_sn: partial_sn} = state,
+         new_partial_sn
+       ) do
+    new_segment? = new_partial_sn < partial_sn
+
+    if new_segment? do
+      state = %{state | segment_sn: segment_sn + 1, partial_sn: new_partial_sn}
+      # If there is a new segment we want to remove partials that are to old from ets
+      remove_partials_from_ets(state)
+    else
+      %{state | partial_sn: new_partial_sn}
+    end
+  end
+
+  defp write_to_file(directory, filename, content, write_options \\ []) do
+    directory
+    |> Path.join(filename)
+    |> File.write(content, write_options)
+  end
+end

--- a/lib/jellyfish/component/hls/request_handler.ex
+++ b/lib/jellyfish/component/hls/request_handler.ex
@@ -98,7 +98,7 @@ defmodule Jellyfish.Component.HLS.RequestHandler do
   ### MANAGMENT API
   ###
 
-  def start(%{room_id: room_id}) do
+  def start(room_id) do
     # Request handler monitors the room process.
     # This ensures that it will be killed if room crashes.
     # In case of different use of this module it has to be refactored

--- a/lib/jellyfish/component/hls/request_handler.ex
+++ b/lib/jellyfish/component/hls/request_handler.ex
@@ -36,9 +36,10 @@ defmodule Jellyfish.Component.HLS.RequestHandler do
   """
   @spec handle_file_request(Room.id(), String.t()) :: {:ok, binary()} | {:error | String.t()}
   def handle_file_request(room_id, filename) do
-    hls_directory = HLS.output_dir(room_id)
-    path = Path.join(hls_directory, filename)
-    File.read(path)
+    room_id
+    |> HLS.output_dir()
+    |> Path.join(filename)
+    |> File.read()
   end
 
   @doc """
@@ -197,17 +198,11 @@ defmodule Jellyfish.Component.HLS.RequestHandler do
     false
   end
 
-  defp is_partial_ready(partial, last_partial),
-    do:
-      is_last_segment_sn_greater(partial, last_partial) or
-        is_same_segment_greater_or_equal_partial_sn(partial, last_partial)
-
-  defp is_last_segment_sn_greater({segment_sn, _partial_sn}, {last_segment_sn, _last_partial_sn}),
-    do: last_segment_sn > segment_sn
-
-  defp is_same_segment_greater_or_equal_partial_sn(
-         {segment_sn, partial_sn},
-         {last_segment_sn, last_partial_sn}
-       ),
-       do: last_segment_sn == segment_sn and last_partial_sn >= partial_sn
+  defp is_partial_ready({segment_sn, partial_sn}, {last_segment_sn, last_partial_sn}) do
+    cond do
+      last_segment_sn > segment_sn -> true
+      last_segment_sn < segment_sn -> false
+      true -> last_partial_sn >= partial_sn
+    end
+  end
 end

--- a/lib/jellyfish/component/hls/request_handler.ex
+++ b/lib/jellyfish/component/hls/request_handler.ex
@@ -1,0 +1,141 @@
+defmodule Jellyfish.Component.HLS.RequestHandler do
+  @moduledoc false
+
+  use GenServer
+  use Bunch.Access
+
+  alias Jellyfish.Component.HLS.EtsHelper
+  alias Jellyfish.Room
+
+  @enforce_keys [:room_id]
+  defstruct @enforce_keys ++
+              [
+                manifest: %{waiting_pids: %{}, last_partial: nil},
+                delta_manifest: %{waiting_pids: %{}, last_partial: nil}
+              ]
+
+  @type segment_sn :: non_neg_integer()
+  @type partial_sn :: non_neg_integer()
+  @type partial :: {segment_sn(), partial_sn()}
+  @type manifest :: %{waiting_pids: %{partial() => [pid()]}, last_partial: partial() | nil}
+
+  @type t :: %__MODULE__{
+          room_id: Room.id(),
+          manifest: manifest(),
+          delta_manifest: manifest()
+        }
+
+  @hls_directory "jellyfish_output/hls_output"
+
+  @doc """
+  Handles requests: playlists (regular hls), master playlist, headers, regular segments
+  """
+  @spec handle_file_request(Room.id(), String.t()) :: {:ok, binary()} | {:error | String.t()}
+  def handle_file_request(room_id, filename) do
+    path = Path.join([@hls_directory, room_id, filename])
+    File.read(path)
+  end
+
+  @spec handle_partial_request(Room.id(), String.t(), non_neg_integer()) ::
+          {:ok, binary()} | {:error | String.t()}
+  def handle_partial_request(room_id, filename, offset) do
+    EtsHelper.get_partial(room_id, filename, offset)
+  end
+
+  @doc """
+  Should be called only when ll-hls
+  """
+  @spec handle_manifest_request(Room.id(), String.t(), partial()) :: binary()
+  def handle_manifest_request(room_id, filename, partial) do
+    last_partial = EtsHelper.get_last_partial(room_id, filename)
+
+    unless is_partial_ready(partial, last_partial) do
+      wait_for_manifest_ready(room_id, partial, filename)
+    end
+
+    EtsHelper.get_manifest(room_id, filename)
+  end
+
+  @spec update_last_partial(Room.id(), partial(), :regular | :delta) :: :ok
+  def update_last_partial(room_id, partial, type) do
+    GenServer.cast(registry_id(room_id), {:update_last_partial, partial, type})
+  end
+
+  def start(%{room_id: room_id} = config) do
+    GenServer.start(__MODULE__, config, name: registry_id(room_id))
+  end
+
+  @impl true
+  def init(%{room_id: room_id}), do: {:ok, %__MODULE__{room_id: room_id}}
+
+  @impl true
+  def handle_cast({:update_last_partial, last_partial, type}, state) do
+    manifest_type = if type == :regular, do: :manifest, else: :delta_manifest
+
+    {waiting_pids, manifest} =
+      state
+      |> Map.get(manifest_type)
+      |> Map.put(:last_partial, last_partial)
+      |> pop_in([:waiting_pids, last_partial])
+
+    send_partial_ready(waiting_pids)
+
+    state = Map.put(state, manifest_type, manifest)
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_cast({:is_partial_ready, partial, filename, from}, state) do
+    manifest_type =
+      if String.contains?(filename, "_delta.m3u8"), do: :delta_manifest, else: :manifest
+
+    manifest = Map.get(state, manifest_type)
+
+    manifest =
+      if is_partial_ready(partial, manifest.last_partial) do
+        send(from, :manifest_ready)
+        manifest
+      else
+        waiting_pids =
+          Map.update(manifest.waiting_pids, partial, [from], fn pids_list ->
+            [from | pids_list]
+          end)
+
+        %{manifest | waiting_pids: waiting_pids}
+      end
+
+    state = Map.put(state, manifest_type, manifest)
+    {:noreply, state}
+  end
+
+  @impl true
+  def terminate(_reason, %{room_id: room_id}) do
+    EtsHelper.remove_room(room_id)
+  end
+
+  defp wait_for_manifest_ready(room_id, partial, filename) do
+    GenServer.cast(registry_id(room_id), {:is_partial_ready, partial, filename, self()})
+
+    receive do
+      :manifest_ready ->
+        :ok
+    end
+  end
+
+  defp registry_id(room_id), do: {:via, Registry, {Jellyfish.RequestHandlerRegistry, room_id}}
+
+  defp send_partial_ready(nil), do: nil
+
+  defp send_partial_ready(waiting_pids) do
+    Enum.each(waiting_pids, fn pid -> send(pid, :manifest_ready) end)
+  end
+
+  defp is_partial_ready(_partial, nil) do
+    false
+  end
+
+  defp is_partial_ready(partial, last_partial),
+    do: partial_to_integer(last_partial) >= partial_to_integer(partial)
+
+  defp partial_to_integer({segment_sn, partial_sn}), do: segment_sn * 100 + partial_sn
+end

--- a/lib/jellyfish/component/hls/request_handler.ex
+++ b/lib/jellyfish/component/hls/request_handler.ex
@@ -7,7 +7,7 @@ defmodule Jellyfish.Component.HLS.RequestHandler do
   alias Jellyfish.Component.HLS.EtsHelper
   alias Jellyfish.Room
 
-  @enforce_keys [:room_id]
+  @enforce_keys [:room_id, :room_pid]
   defstruct @enforce_keys ++
               [
                 manifest: %{waiting_pids: %{}, last_partial: nil},
@@ -17,15 +17,20 @@ defmodule Jellyfish.Component.HLS.RequestHandler do
   @type segment_sn :: non_neg_integer()
   @type partial_sn :: non_neg_integer()
   @type partial :: {segment_sn(), partial_sn()}
-  @type manifest :: %{waiting_pids: %{partial() => [pid()]}, last_partial: partial() | nil}
+  @type status :: %{waiting_pids: %{partial() => [pid()]}, last_partial: partial() | nil}
 
   @type t :: %__MODULE__{
           room_id: Room.id(),
-          manifest: manifest(),
-          delta_manifest: manifest()
+          room_pid: pid(),
+          manifest: status(),
+          delta_manifest: status()
         }
 
   @hls_directory "jellyfish_output/hls_output"
+
+  ###
+  ### HLS Controller API
+  ###
 
   @doc """
   Handles requests: playlists (regular hls), master playlist, headers, regular segments
@@ -36,76 +41,104 @@ defmodule Jellyfish.Component.HLS.RequestHandler do
     File.read(path)
   end
 
+  @doc """
+  Handles ll-hls partial requests
+  """
   @spec handle_partial_request(Room.id(), String.t(), non_neg_integer()) ::
-          {:ok, binary()} | {:error | String.t()}
+          {:ok, binary()} | {:error | atom()}
   def handle_partial_request(room_id, filename, offset) do
     EtsHelper.get_partial(room_id, filename, offset)
   end
 
   @doc """
-  Should be called only when ll-hls
+  Handles manifest requests with specific partial requested (ll-hls)
   """
-  @spec handle_manifest_request(Room.id(), String.t(), partial()) :: binary()
-  def handle_manifest_request(room_id, filename, partial) do
-    last_partial = EtsHelper.get_last_partial(room_id, filename)
+  @spec handle_manifest_request(Room.id(), partial()) :: {:ok, binary()} | {:error, any()}
+  def handle_manifest_request(room_id, partial) do
+    {:ok, last_partial} = EtsHelper.get_recent_partial(room_id)
 
-    unless is_partial_ready(partial, last_partial) do
-      wait_for_manifest_ready(room_id, partial, filename)
+    unless is_partial_ready?(partial, last_partial) do
+      wait_for_manifest_ready(room_id, partial)
     end
 
-    EtsHelper.get_manifest(room_id, filename)
+    EtsHelper.get_manifest(room_id)
   end
 
-  @spec update_last_partial(Room.id(), partial(), :regular | :delta) :: :ok
-  def update_last_partial(room_id, partial, type) do
-    GenServer.cast(registry_id(room_id), {:update_last_partial, partial, type})
+  @doc """
+  Handles manifest requests with specific partial requested (ll-hls)
+  """
+  @spec handle_delta_manifest_request(Room.id(), partial()) :: {:ok, String.t()} | {:error, any()}
+  def handle_delta_manifest_request(room_id, partial) do
+    {:ok, last_partial} = EtsHelper.get_delta_recent_partial(room_id)
+
+    unless is_partial_ready?(partial, last_partial) do
+      wait_for_delta_manifest_ready(room_id, partial)
+    end
+
+    EtsHelper.get_delta_manifest(room_id)
   end
 
-  def start(%{room_id: room_id} = config) do
-    GenServer.start(__MODULE__, config, name: registry_id(room_id))
+  ###
+  ### STORAGE API
+  ###
+
+  @spec update_recent_partial(Room.id(), partial()) :: :ok
+  def update_recent_partial(room_id, partial) do
+    GenServer.cast(registry_id(room_id), {:update_recent_partial, partial})
+  end
+
+  @spec update_delta_recent_partial(Room.id(), partial()) :: :ok
+  def update_delta_recent_partial(room_id, partial) do
+    GenServer.cast(registry_id(room_id), {:update_delta_recent_partial, partial})
+  end
+
+  ###
+  ### MANAGMENT API
+  ###
+
+  def start(%{room_id: room_id}) do
+    GenServer.start(__MODULE__, %{room_id: room_id, room_pid: self()}, name: registry_id(room_id))
+  end
+
+  def stop(room_id) do
+    GenServer.cast(registry_id(room_id), :shutdown)
   end
 
   @impl true
-  def init(%{room_id: room_id}), do: {:ok, %__MODULE__{room_id: room_id}}
+  def init(%{room_id: room_id, room_pid: room_pid}) do
+    Process.monitor(room_pid)
+    {:ok, %__MODULE__{room_id: room_id, room_pid: room_pid}}
+  end
 
   @impl true
-  def handle_cast({:update_last_partial, last_partial, type}, state) do
-    manifest_type = if type == :regular, do: :manifest, else: :delta_manifest
-
-    {waiting_pids, manifest} =
-      state
-      |> Map.get(manifest_type)
-      |> Map.put(:last_partial, last_partial)
-      |> pop_in([:waiting_pids, last_partial])
-
-    send_partial_ready(waiting_pids)
-
-    state = Map.put(state, manifest_type, manifest)
+  def handle_cast({:update_recent_partial, last_partial}, %{manifest: status} = state) do
+    state = Map.put(state, :manifest, update_status(status, last_partial))
     {:noreply, state}
   end
 
   @impl true
-  def handle_cast({:is_partial_ready, partial, filename, from}, state) do
-    manifest_type =
-      if String.contains?(filename, "_delta.m3u8"), do: :delta_manifest, else: :manifest
-
-    manifest = Map.get(state, manifest_type)
-
-    manifest =
-      if is_partial_ready(partial, manifest.last_partial) do
-        send(from, :manifest_ready)
-        manifest
-      else
-        waiting_pids =
-          Map.update(manifest.waiting_pids, partial, [from], fn pids_list ->
-            [from | pids_list]
-          end)
-
-        %{manifest | waiting_pids: waiting_pids}
-      end
-
-    state = Map.put(state, manifest_type, manifest)
+  def handle_cast({:update_delta_recent_partial, last_partial}, %{delta_manifest: status} = state) do
+    state = Map.put(state, :delta_manifest, update_status(status, last_partial))
     {:noreply, state}
+  end
+
+  @impl true
+  def handle_cast({:is_partial_ready, partial, from}, %{manifest: status} = state) do
+    status = handle_is_partial_ready(status, partial, from)
+    state = Map.put(state, :manifest, status)
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_cast({:is_delta_partial_ready, partial, from}, %{delta_manifest: status} = state) do
+    status = handle_is_partial_ready(status, partial, from)
+    state = Map.put(state, :delta_manifest, status)
+    {:noreply, state}
+  end
+
+  @impl true
+  def handle_cast(:shutdown, state) do
+    {:stop, :normal, state}
   end
 
   @impl true
@@ -113,12 +146,54 @@ defmodule Jellyfish.Component.HLS.RequestHandler do
     EtsHelper.remove_room(room_id)
   end
 
-  defp wait_for_manifest_ready(room_id, partial, filename) do
-    GenServer.cast(registry_id(room_id), {:is_partial_ready, partial, filename, self()})
+  @impl true
+  def handle_info({:DOWN, _ref, :process, pid, _reason}, %{room_pid: pid} = state) do
+    {:stop, :normal, state}
+  end
+
+  ###
+  ### PRIVATE FUNCTIONS
+  ###
+
+  defp wait_for_manifest_ready(room_id, partial) do
+    GenServer.cast(registry_id(room_id), {:is_partial_ready, partial, self()})
 
     receive do
       :manifest_ready ->
         :ok
+    end
+  end
+
+  defp wait_for_delta_manifest_ready(room_id, partial) do
+    GenServer.cast(registry_id(room_id), {:is_delta_partial_ready, partial, self()})
+
+    receive do
+      :manifest_ready ->
+        :ok
+    end
+  end
+
+  defp update_status(status, last_partial) do
+    {waiting_pids, status} =
+      status
+      |> Map.put(:last_partial, last_partial)
+      |> pop_in([:waiting_pids, last_partial])
+
+    send_partial_ready(waiting_pids)
+    status
+  end
+
+  defp handle_is_partial_ready(status, partial, from) do
+    if is_partial_ready?(partial, status.last_partial) do
+      send(from, :manifest_ready)
+      status
+    else
+      waiting_pids =
+        Map.update(status.waiting_pids, partial, [from], fn pids_list ->
+          [from | pids_list]
+        end)
+
+      %{status | waiting_pids: waiting_pids}
     end
   end
 
@@ -130,11 +205,11 @@ defmodule Jellyfish.Component.HLS.RequestHandler do
     Enum.each(waiting_pids, fn pid -> send(pid, :manifest_ready) end)
   end
 
-  defp is_partial_ready(_partial, nil) do
+  defp is_partial_ready?(_partial, nil) do
     false
   end
 
-  defp is_partial_ready(partial, last_partial),
+  defp is_partial_ready?(partial, last_partial),
     do: partial_to_integer(last_partial) >= partial_to_integer(partial)
 
   defp partial_to_integer({segment_sn, partial_sn}), do: segment_sn * 100 + partial_sn

--- a/lib/jellyfish/component/hls/storage.ex
+++ b/lib/jellyfish/component/hls/storage.ex
@@ -1,0 +1,201 @@
+defmodule Jellyfish.Component.HLS.Storage do
+  @moduledoc false
+
+  @behaviour Membrane.HTTPAdaptiveStream.Storage
+
+  alias Jellyfish.Room
+
+  @enforce_keys [:directory, :room_id]
+  defstruct @enforce_keys ++ [partial_sn: nil, segment_sn: 0, partials_in_ets: []]
+
+  @type partial_ets_key :: String.t()
+  @type segment_sn :: non_neg_integer()
+  @type partial_sn :: non_neg_integer()
+  @type partial_in_ets :: {{segment_sn(), partial_sn()}, partial_ets_key()}
+
+  @type t :: %__MODULE__{
+          directory: Path.t(),
+          room_id: Room.id(),
+          partial_sn: partial_sn() | nil,
+          segment_sn: segment_sn(),
+          partials_in_ets: [partial_in_ets()]
+        }
+
+  @manifest_key :manifest
+  @last_partial_key :last_partial
+
+  @ets_duration_in_segments 4
+
+  @impl true
+  def init(%{directory: directory, room_id: room_id}) do
+    # Initializes ets storage that will serve partial segments and manifests
+    :ets.new(room_id, [:public, :set, :named_table])
+
+    %__MODULE__{room_id: room_id, directory: directory}
+  end
+
+  @impl true
+  def store(_perent_id, name, content, metadata, context, state) do
+    case context do
+      %{mode: :binary, type: :segment} ->
+        store_segment(name, content, state)
+
+      %{mode: :binary, type: :partial_segment} ->
+        store_partial_segment(name, content, metadata, state)
+
+      %{mode: :binary, type: :header} ->
+        store_header(name, content, state)
+
+      %{mode: :text, type: :manifest} ->
+        store_manifest(name, content, state)
+    end
+  end
+
+  @impl true
+  def remove(_parent_id, name, _ctx, %__MODULE__{directory: directory} = state) do
+    result =
+      directory
+      |> Path.join(name)
+      |> File.rm()
+
+    {result, state}
+  end
+
+  defp store_segment(
+         filename,
+         content,
+         %{directory: directory} = state
+       ) do
+    result =
+      directory
+      |> Path.join(filename)
+      |> File.write(content, [:binary])
+
+    {result, state}
+  end
+
+  defp store_partial_segment(
+         filename,
+         content,
+         %{byte_offset: offset, sequence_number: sequence_number},
+         %__MODULE__{directory: directory} = state
+       ) do
+    result =
+      directory
+      |> Path.join(filename)
+      |> File.write(content, [:binary, :append])
+
+    state =
+      state
+      |> update_sequence_numbers(sequence_number)
+      |> add_partial_to_ets(filename, offset, content)
+
+    {result, state}
+  end
+
+  defp store_header(
+         filename,
+         content,
+         %__MODULE__{directory: directory} = state
+       ) do
+    result =
+      directory
+      |> Path.join(filename)
+      |> File.write(content, [:binary])
+
+    {result, state}
+  end
+
+  defp store_manifest(
+         filename,
+         content,
+         %__MODULE__{directory: directory} = state
+       ) do
+    result =
+      directory
+      |> Path.join(filename)
+      |> File.write(content)
+
+    add_manifest_to_ets(content, state)
+    send_update(state)
+
+    {result, state}
+  end
+
+  # first partial
+  defp update_sequence_numbers(%{partial_sn: nil} = state, new_partial_sn),
+    do: %{state | partial_sn: new_partial_sn}
+
+  defp update_sequence_numbers(
+         %{segment_sn: segment_sn, partial_sn: partial_sn} = state,
+         new_partial_sn
+       ) do
+    new_segment? = new_partial_sn < partial_sn
+
+    if new_segment? do
+      state = %{state | segment_sn: segment_sn + 1, partial_sn: new_partial_sn}
+      # If there is a new segment we want to remove partials that are to old from ets
+      remove_partials_from_ets(state)
+    else
+      %{state | partial_sn: new_partial_sn}
+    end
+  end
+
+  defp remove_partials_from_ets(
+         %{partials_in_ets: partials_in_ets, segment_sn: curr_segment_sn, room_id: room_id} =
+           state
+       ) do
+    # Remove all partials that are at least @ets_duration_in_segments behind
+    partials_in_ets =
+      Enum.filter(partials_in_ets, fn {{segment_sn, _partial_sn}, key} ->
+        if segment_sn + @ets_duration_in_segments <= curr_segment_sn do
+          :ets.delete(room_id, key)
+          false
+        else
+          true
+        end
+      end)
+
+    %{state | partials_in_ets: partials_in_ets}
+  end
+
+  defp add_partial_to_ets(
+         %{
+           room_id: room_id,
+           partials_in_ets: partials_in_ets,
+           segment_sn: segment_sn,
+           partial_sn: partial_sn
+         } = state,
+         filename,
+         offset,
+         content
+       ) do
+    key = "#{filename}_#{offset}"
+    partial = {segment_sn, partial_sn}
+
+    :ets.insert(room_id, {key, content})
+
+    %{state | partials_in_ets: [{partial, key} | partials_in_ets]}
+  end
+
+  # In case of regular hls we don't want to send anything to ets
+  defp add_manifest_to_ets(_manifest, %{partial_sn: nil}), do: nil
+
+  defp add_manifest_to_ets(manifest, %{
+         segment_sn: segment_sn,
+         partial_sn: partial_sn,
+         room_id: room_id
+       }) do
+    :ets.insert(room_id, {@manifest_key, manifest})
+    :ets.insert(room_id, {@last_partial_key, {segment_sn, partial_sn}})
+  end
+
+  # In case of regular hls we don't want to send anything to ets
+  defp send_update(%{partial_sn: nil}), do: nil
+
+  defp send_update(%{room_id: _room_id, segment_sn: _segment_sn, partial_sn: _partial_sn}) do
+    # Not implemented
+    # PartialState.update(room_id, {segment_sn, partial_sn})
+    nil
+  end
+end

--- a/lib/jellyfish/component/hls/storage.ex
+++ b/lib/jellyfish/component/hls/storage.ex
@@ -9,8 +9,8 @@ defmodule Jellyfish.Component.HLS.Storage do
   @type t :: %__MODULE__{directory: Path.t()}
 
   @impl true
-  def init(%__MODULE__{directory: directory}),
-    do: %__MODULE__{directory: directory}
+  def init(%__MODULE__{} = state),
+    do: state
 
   @impl true
   def store(
@@ -27,7 +27,7 @@ defmodule Jellyfish.Component.HLS.Storage do
           write_to_file(directory, name, content, [:binary])
 
         %{mode: :binary, type: :partial_segment} ->
-          raise "This storage doesn't support ll-hls"
+          raise "This storage doesn't support ll-hls. Use `Jellyfish.Component.HLS.LLStorage` instead"
 
         %{mode: :binary, type: :header} ->
           write_to_file(directory, name, content, [:binary])

--- a/lib/jellyfish/component/hls/storage.ex
+++ b/lib/jellyfish/component/hls/storage.ex
@@ -3,52 +3,40 @@ defmodule Jellyfish.Component.HLS.Storage do
 
   @behaviour Membrane.HTTPAdaptiveStream.Storage
 
-  alias Jellyfish.Room
+  @enforce_keys [:directory]
+  defstruct @enforce_keys ++ []
 
-  @enforce_keys [:directory, :room_id]
-  defstruct @enforce_keys ++ [partial_sn: nil, segment_sn: 0, partials_in_ets: []]
-
-  @type partial_ets_key :: String.t()
-  @type sequence_number :: non_neg_integer()
-  @type partial_in_ets ::
-          {{segment_sn :: sequence_number(), partial_sn :: sequence_number()}, partial_ets_key()}
-
-  @type t :: %__MODULE__{
-          directory: Path.t(),
-          room_id: Room.id(),
-          partial_sn: sequence_number() | nil,
-          segment_sn: sequence_number(),
-          partials_in_ets: [partial_in_ets()]
-        }
-
-  @manifest_key :manifest
-  @last_partial_key :last_partial
-
-  @ets_duration_in_segments 4
+  @type t :: %__MODULE__{directory: Path.t()}
 
   @impl true
-  def init(%{directory: directory, room_id: room_id}) do
-    # Initializes ets storage that will serve partial segments and manifests
-    :ets.new({__MODULE__, room_id}, [:public, :set, :named_table])
-
-    %__MODULE__{room_id: room_id, directory: directory}
-  end
+  def init(%__MODULE__{directory: directory}),
+    do: %__MODULE__{directory: directory}
 
   @impl true
-  def store(_parent_id, name, content, metadata, context, state) do
-    case context do
-      %{mode: :binary, type: :segment} ->
-        store_segment(name, content, state)
+  def store(
+        _parent_id,
+        name,
+        content,
+        _metadata,
+        context,
+        %__MODULE__{directory: directory} = state
+      ) do
+    result =
+      case context do
+        %{mode: :binary, type: :segment} ->
+          write_to_file(directory, name, content, [:binary])
 
-      %{mode: :binary, type: :partial_segment} ->
-        store_partial_segment(name, content, metadata, state)
+        %{mode: :binary, type: :partial_segment} ->
+          raise "This storage doesn't support ll-hls"
 
-      %{mode: :binary, type: :header} ->
-        store_header(name, content, state)
+        %{mode: :binary, type: :header} ->
+          write_to_file(directory, name, content, [:binary])
 
-      %{mode: :text, type: :manifest} ->
-        store_manifest(name, content, state)
-    end
+        %{mode: :text, type: :manifest} ->
+          write_to_file(directory, name, content)
+      end
+
+    {result, state}
   end
 
   @impl true
@@ -61,133 +49,9 @@ defmodule Jellyfish.Component.HLS.Storage do
     {result, state}
   end
 
-  defp store_segment(
-         filename,
-         content,
-         %{directory: directory} = state
-       ) do
-    result = write_to_file(directory, filename, content, [:binary])
-    {result, state}
-  end
-
-  defp store_partial_segment(
-         filename,
-         content,
-         %{byte_offset: offset, sequence_number: sequence_number},
-         %__MODULE__{directory: directory} = state
-       ) do
-    result = write_to_file(directory, filename, content, [:binary, :append])
-
-    state =
-      state
-      |> update_sequence_numbers(sequence_number)
-      |> add_partial_to_ets(filename, offset, content)
-
-    {result, state}
-  end
-
-  defp store_header(
-         filename,
-         content,
-         %__MODULE__{directory: directory} = state
-       ) do
-    result = write_to_file(directory, filename, content, [:binary])
-    {result, state}
-  end
-
-  defp store_manifest(
-         filename,
-         content,
-         %__MODULE__{directory: directory} = state
-       ) do
-    result = write_to_file(directory, filename, content)
-
-    add_manifest_to_ets(content, state)
-    send_update(state)
-
-    {result, state}
-  end
-
   defp write_to_file(directory, filename, content, write_options \\ []) do
     directory
     |> Path.join(filename)
     |> File.write(content, write_options)
-  end
-
-  # first partial
-  defp update_sequence_numbers(%{partial_sn: nil} = state, new_partial_sn),
-    do: %{state | partial_sn: new_partial_sn}
-
-  defp update_sequence_numbers(
-         %{segment_sn: segment_sn, partial_sn: partial_sn} = state,
-         new_partial_sn
-       ) do
-    new_segment? = new_partial_sn < partial_sn
-
-    if new_segment? do
-      state = %{state | segment_sn: segment_sn + 1, partial_sn: new_partial_sn}
-      # If there is a new segment we want to remove partials that are to old from ets
-      remove_partials_from_ets(state)
-    else
-      %{state | partial_sn: new_partial_sn}
-    end
-  end
-
-  defp remove_partials_from_ets(
-         %{partials_in_ets: partials_in_ets, segment_sn: curr_segment_sn, room_id: room_id} =
-           state
-       ) do
-    # Remove all partials that are at least @ets_duration_in_segments behind
-    partials_in_ets =
-      Enum.filter(partials_in_ets, fn {{segment_sn, _partial_sn}, key} ->
-        if segment_sn + @ets_duration_in_segments <= curr_segment_sn do
-          :ets.delete({__MODULE__, room_id}, key)
-          false
-        else
-          true
-        end
-      end)
-
-    %{state | partials_in_ets: partials_in_ets}
-  end
-
-  defp add_partial_to_ets(
-         %{
-           room_id: room_id,
-           partials_in_ets: partials_in_ets,
-           segment_sn: segment_sn,
-           partial_sn: partial_sn
-         } = state,
-         filename,
-         offset,
-         content
-       ) do
-    key = "#{filename}_#{offset}"
-    partial = {segment_sn, partial_sn}
-
-    :ets.insert({__MODULE__, room_id}, {key, content})
-
-    %{state | partials_in_ets: [{partial, key} | partials_in_ets]}
-  end
-
-  # In case of regular hls we don't want to send anything to ets
-  defp add_manifest_to_ets(_manifest, %{partial_sn: nil}), do: nil
-
-  defp add_manifest_to_ets(manifest, %{
-         segment_sn: segment_sn,
-         partial_sn: partial_sn,
-         room_id: room_id
-       }) do
-    :ets.insert({__MODULE__, room_id}, {@manifest_key, manifest})
-    :ets.insert({__MODULE__, room_id}, {@last_partial_key, {segment_sn, partial_sn}})
-  end
-
-  # In case of regular hls we don't want to send anything to ets
-  defp send_update(%{partial_sn: nil}), do: nil
-
-  defp send_update(%{room_id: _room_id, segment_sn: _segment_sn, partial_sn: _partial_sn}) do
-    # Not implemented
-    # PartialState.update(room_id, {segment_sn, partial_sn})
-    nil
   end
 end

--- a/lib/jellyfish/room.ex
+++ b/lib/jellyfish/room.ex
@@ -256,10 +256,12 @@ defmodule Jellyfish.Room do
   def handle_call({:remove_component, component_id}, _from, state) do
     {reply, state} =
       if Map.has_key?(state.components, component_id) do
-        {_elem, state} = pop_in(state, [:components, component_id])
+        {component, state} = pop_in(state, [:components, component_id])
         :ok = Engine.remove_endpoint(state.engine_pid, component_id)
 
         Logger.info("Removed component #{inspect(component_id)}")
+
+        if component.type == Component.HLS, do: remove_hls_processes(state.id)
 
         {:ok, state}
       else
@@ -309,6 +311,9 @@ defmodule Jellyfish.Room do
       end
     else
       Event.broadcast(:server_notification, {:component_crashed, state.id, endpoint_id})
+
+      %{type: type} = Map.get(state.components, endpoint_id)
+      if type == Component.HLS, do: remove_hls_processes(state.id)
     end
 
     {:noreply, state}
@@ -388,6 +393,8 @@ defmodule Jellyfish.Room do
       network_options: [integrated_turn_options: integrated_turn_options]
     }
   end
+
+  defp remove_hls_processes(room_id), do: Component.HLS.RequestHandler.stop(room_id)
 
   defp registry_id(room_id), do: {:via, Registry, {Jellyfish.RoomRegistry, room_id}}
 

--- a/lib/jellyfish_web/api_spec/hls.ex
+++ b/lib/jellyfish_web/api_spec/hls.ex
@@ -1,0 +1,48 @@
+defmodule JellyfishWeb.ApiSpec.HLS do
+  require OpenApiSpex
+
+  alias OpenApiSpex.Schema
+
+  defmodule Params do
+    @moduledoc false
+
+    OpenApiSpex.schema(%{
+      title: "HlsParams",
+      description: "Hls request params",
+      type: :object,
+      properties: %{
+        _HLS_msn: %Schema{
+          type: :integer,
+          minimum: 0,
+          example: 10,
+          description: "Segment sequence number",
+          nullable: true
+        },
+        _HLS_part: %Schema{
+          type: :integer,
+          minimum: 0,
+          example: 10,
+          description: "Partial segment sequence number",
+          nullable: true
+        },
+        _HLS_skip: %Schema{
+          type: :string,
+          enum: ["YES"],
+          example: "YES",
+          description: "Is delta manifest requested",
+          nullable: true
+        }
+      }
+    })
+  end
+
+  defmodule Response do
+    @moduledoc false
+
+    OpenApiSpex.schema(%{
+      title: "HlsResponse",
+      description: "Requested file",
+      type: :string
+    })
+  end
+end

--- a/lib/jellyfish_web/controllers/hls_controller.ex
+++ b/lib/jellyfish_web/controllers/hls_controller.ex
@@ -1,0 +1,62 @@
+defmodule JellyfishWeb.HLSController do
+  use JellyfishWeb, :controller
+
+  alias Jellyfish.Component.HLS.RequestHandler
+  alias Plug.Conn
+
+  @hls_directory "jellyfish_output/hls_output"
+
+  def index(
+        conn,
+        %{
+          "_HLS_skip" => _skip
+        } = params
+      ) do
+    params
+    |> Map.update!("filename", &String.replace(&1, ".m3u8", "_delta.m3u8"))
+    |> Map.delete("_HLS_skip")
+    |> then(&index(conn, &1))
+  end
+
+  def index(
+        conn,
+        %{
+          "room_id" => room_id,
+          "filename" => filename,
+          "_HLS_msn" => segment,
+          "_HLS_part" => part
+        }
+      ) do
+    partial = {String.to_integer(segment), String.to_integer(part)}
+    manifest = RequestHandler.handle_manifest_request(room_id, filename, partial)
+    Conn.send_resp(conn, 200, manifest)
+  end
+
+  def index(conn, %{"room_id" => room_id, "filename" => filename}) do
+    range =
+      conn
+      |> get_req_header("range")
+      |> parse_bytes_range()
+
+    if String.match?(filename, ~r/\.m4s$/) and range != :not_partial do
+      {offset, _lenght} = range
+      {:ok, partial_segment} = RequestHandler.handle_partial_request(room_id, filename, offset)
+      Conn.send_resp(conn, 200, partial_segment)
+    else
+      file_path = Path.join([@hls_directory, room_id, filename])
+      Conn.send_file(conn, 200, file_path)
+    end
+  end
+
+  def parse_bytes_range(raw_range) do
+    case raw_range do
+      [] ->
+        :not_partial
+
+      [raw_range] ->
+        "bytes=" <> range = raw_range
+        [first, last] = range |> String.split("-") |> Enum.map(&String.to_integer(&1))
+        {first, last - first + 1}
+    end
+  end
+end

--- a/lib/jellyfish_web/controllers/hls_controller.ex
+++ b/lib/jellyfish_web/controllers/hls_controller.ex
@@ -63,6 +63,10 @@ defmodule JellyfishWeb.HLSController do
     end
   end
 
+  @doc """
+  Every partial request comes with a byte range which represents where specifically in the file partial is located.
+  Example: "bytes=100-10" 100, represents where the partial starts in the file, 10 represents length of partial.
+  """
   def parse_bytes_range(raw_range) do
     case raw_range do
       [] ->

--- a/lib/jellyfish_web/router.ex
+++ b/lib/jellyfish_web/router.ex
@@ -18,6 +18,10 @@ defmodule JellyfishWeb.Router do
     resources("/:room_id/component", ComponentController, only: [:create, :delete])
   end
 
+  scope "/hls", JellyfishWeb do
+    get "/:room_id/:filename", HLSController, :index
+  end
+
   # Enable LiveDashboard in development
   if Application.compile_env(:jellyfish, :dev_routes) do
     # If you want to use the LiveDashboard in production, you should put

--- a/lib/protos/jellyfish/server_notifications.pb.ex
+++ b/lib/protos/jellyfish/server_notifications.pb.ex
@@ -112,28 +112,6 @@ defmodule Jellyfish.ServerMessage.MetricsReport do
   field :metrics, 1, type: :string
 end
 
-defmodule Jellyfish.ServerMessage.RoomNotFound do
-  @moduledoc false
-
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
-
-  field :room_id, 1, type: :string, json_name: "roomId"
-end
-
-defmodule Jellyfish.ServerMessage.GetRoomIds do
-  @moduledoc false
-
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
-end
-
-defmodule Jellyfish.ServerMessage.RoomIds do
-  @moduledoc false
-
-  use Protobuf, protoc_gen_elixir_version: "0.12.0", syntax: :proto3
-
-  field :ids, 1, repeated: true, type: :string
-end
-
 defmodule Jellyfish.ServerMessage.HlsPlayable do
   @moduledoc false
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -111,6 +111,36 @@ components:
       title: Error
       type: object
       x-struct: Elixir.JellyfishWeb.ApiSpec.Error
+    HlsParams:
+      description: Hls request params
+      properties:
+        _HLS_msn:
+          description: Segment sequence number
+          example: 10
+          minimum: 0
+          nullable: true
+          type: integer
+        _HLS_part:
+          description: Partial segment sequence number
+          example: 10
+          minimum: 0
+          nullable: true
+          type: integer
+        _HLS_skip:
+          description: Is delta manifest requested
+          enum:
+            - YES
+          example: YES
+          nullable: true
+          type: string
+      title: HlsParams
+      type: object
+      x-struct: Elixir.JellyfishWeb.ApiSpec.HLS.Params
+    HlsResponse:
+      description: Requested file
+      title: HlsResponse
+      type: string
+      x-struct: Elixir.JellyfishWeb.ApiSpec.HLS.Response
     Peer:
       description: Describes peer status
       properties:
@@ -274,6 +304,51 @@ info:
   version: 0.2.0
 openapi: 3.0.0
 paths:
+  /hls/{room_id}/{filename}:
+    get:
+      callbacks: {}
+      operationId: JellyfishWeb.HLSController.index
+      parameters:
+        - description: Room id
+          in: path
+          name: room_id
+          required: true
+          schema:
+            type: string
+        - description: Name of the file
+          in: path
+          name: filename
+          required: true
+          schema:
+            type: string
+        - description: Byte range of partial segment
+          in: header
+          name: range
+          required: false
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/HlsParams'
+        description: HLSparams
+        required: false
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HlsResponse'
+          description: File was found
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: File not found
+      summary: Send file
+      tags: []
   /room:
     get:
       callbacks: {}

--- a/test/jellyfish/component/hls/ets_helper_test.exs
+++ b/test/jellyfish/component/hls/ets_helper_test.exs
@@ -18,7 +18,7 @@ defmodule Jellyfish.Component.HLS.EtsHelperTest do
   @offset 0
   @wrong_offset 1
 
-  @rooms_to_tabels :rooms_to_tables
+  @rooms_to_tables :rooms_to_tables
 
   setup do
     room_id = UUID.uuid4()
@@ -32,61 +32,64 @@ defmodule Jellyfish.Component.HLS.EtsHelperTest do
 
   test "rooms managment" do
     room_id = UUID.uuid4()
-    {:error, :room_not_found} = EtsHelper.get_partial(room_id, @partial_name, @offset)
+    assert {:error, :room_not_found} == EtsHelper.get_partial(room_id, @partial_name, @offset)
 
     {:ok, table} = EtsHelper.add_room(room_id)
-    {:error, :already_exists} = EtsHelper.add_room(room_id)
+    assert {:error, :already_exists} == EtsHelper.add_room(room_id)
 
-    [{room_id, ^table}] = :ets.lookup(@rooms_to_tabels, room_id)
+    assert [{room_id, table}] == :ets.lookup(@rooms_to_tables, room_id)
 
     :ok = EtsHelper.remove_room(room_id)
-    {:error, _reason} = EtsHelper.remove_room(room_id)
+    assert {:error, "Room: #{room_id} doesn't exist"} == EtsHelper.remove_room(room_id)
 
-    assert [] == :ets.lookup(@rooms_to_tabels, room_id)
-    assert_raise ArgumentError, fn -> :ets.lookup(table, room_id) end
+    assert [] == :ets.lookup(@rooms_to_tables, room_id)
   end
 
   test "partials managment", %{room_id: room_id, table: table} do
-    {:error, :file_not_found} = EtsHelper.get_partial(room_id, @partial_name, @offset)
+    assert {:error, :file_not_found} == EtsHelper.get_partial(room_id, @partial_name, @offset)
 
     EtsHelper.add_partial(table, @partial, @partial_name, @offset)
 
-    {:ok, @partial} = EtsHelper.get_partial(room_id, @partial_name, @offset)
-    {:error, :file_not_found} = EtsHelper.get_partial(room_id, @partial_name, @wrong_offset)
-    {:error, :file_not_found} = EtsHelper.get_partial(room_id, @wrong_partial_name, @offset)
+    assert {:ok, @partial} == EtsHelper.get_partial(room_id, @partial_name, @offset)
+
+    assert {:error, :file_not_found} ==
+             EtsHelper.get_partial(room_id, @partial_name, @wrong_offset)
+
+    assert {:error, :file_not_found} ==
+             EtsHelper.get_partial(room_id, @wrong_partial_name, @offset)
 
     EtsHelper.delete_partial(table, @partial_name, @offset)
 
-    {:error, :file_not_found} = EtsHelper.get_partial(room_id, @partial_name, @offset)
+    assert {:error, :file_not_found} == EtsHelper.get_partial(room_id, @partial_name, @offset)
   end
 
   test "manifests managment", %{room_id: room_id, table: table} do
-    {:error, :file_not_found} = EtsHelper.get_manifest(room_id)
-    {:error, :file_not_found} = EtsHelper.get_delta_manifest(room_id)
+    assert {:error, :file_not_found} == EtsHelper.get_manifest(room_id)
+    assert {:error, :file_not_found} == EtsHelper.get_delta_manifest(room_id)
 
     EtsHelper.update_manifest(table, @manifest)
 
-    {:ok, @manifest} = EtsHelper.get_manifest(room_id)
-    {:error, :file_not_found} = EtsHelper.get_delta_manifest(room_id)
+    assert {:ok, @manifest} == EtsHelper.get_manifest(room_id)
+    assert {:error, :file_not_found} == EtsHelper.get_delta_manifest(room_id)
 
     EtsHelper.update_delta_manifest(table, @delta_manifest)
 
-    {:ok, @manifest} = EtsHelper.get_manifest(room_id)
-    {:ok, @delta_manifest} = EtsHelper.get_delta_manifest(room_id)
+    assert {:ok, @manifest} == EtsHelper.get_manifest(room_id)
+    assert {:ok, @delta_manifest} == EtsHelper.get_delta_manifest(room_id)
   end
 
   test "recent partial managment", %{room_id: room_id, table: table} do
-    {:error, :file_not_found} = EtsHelper.get_recent_partial(room_id)
-    {:error, :file_not_found} = EtsHelper.get_delta_recent_partial(room_id)
+    assert {:error, :file_not_found} == EtsHelper.get_recent_partial(room_id)
+    assert {:error, :file_not_found} == EtsHelper.get_delta_recent_partial(room_id)
 
     EtsHelper.update_recent_partial(table, @recent_partial)
 
-    {:ok, @recent_partial} = EtsHelper.get_recent_partial(room_id)
-    {:error, :file_not_found} = EtsHelper.get_delta_recent_partial(room_id)
+    assert {:ok, @recent_partial} == EtsHelper.get_recent_partial(room_id)
+    assert {:error, :file_not_found} == EtsHelper.get_delta_recent_partial(room_id)
 
     EtsHelper.update_delta_recent_partial(table, @delta_recent_partial)
 
-    {:ok, @recent_partial} = EtsHelper.get_recent_partial(room_id)
-    {:ok, @delta_recent_partial} = EtsHelper.get_delta_recent_partial(room_id)
+    assert {:ok, @recent_partial} == EtsHelper.get_recent_partial(room_id)
+    assert {:ok, @delta_recent_partial} == EtsHelper.get_delta_recent_partial(room_id)
   end
 end

--- a/test/jellyfish/component/hls/ets_helper_test.exs
+++ b/test/jellyfish/component/hls/ets_helper_test.exs
@@ -1,0 +1,92 @@
+defmodule Jellyfish.Component.HLS.EtsHelperTest do
+  @moduledoc false
+
+  use ExUnit.Case, async: false
+
+  alias Jellyfish.Component.HLS.EtsHelper
+
+  @partial <<1, 2, 3>>
+  @partial_name "partial_1"
+  @wrong_partial_name "partial_101"
+
+  @manifest "manifest"
+  @delta_manifest "delta_manifest"
+
+  @recent_partial {1, 1}
+  @delta_recent_partial {2, 2}
+
+  @offset 0
+  @wrong_offset 1
+
+  @rooms_to_tabels :rooms_to_tables
+
+  setup do
+    room_id = UUID.uuid4()
+
+    # Ets tables are not removed during tests because they are automatically removed when the owner process dies.
+    # Therefore, using on_exit (as a separate process) would cause a crash.
+    {:ok, table} = EtsHelper.add_room(room_id)
+
+    %{room_id: room_id, table: table}
+  end
+
+  test "rooms managment" do
+    room_id = UUID.uuid4()
+    {:error, :room_not_found} = EtsHelper.get_partial(room_id, @partial_name, @offset)
+
+    {:ok, table} = EtsHelper.add_room(room_id)
+    {:error, :already_exists} = EtsHelper.add_room(room_id)
+
+    [{room_id, ^table}] = :ets.lookup(@rooms_to_tabels, room_id)
+
+    :ok = EtsHelper.remove_room(room_id)
+    {:error, _reason} = EtsHelper.remove_room(room_id)
+
+    assert [] == :ets.lookup(@rooms_to_tabels, room_id)
+    assert_raise ArgumentError, fn -> :ets.lookup(table, room_id) end
+  end
+
+  test "partials managment", %{room_id: room_id, table: table} do
+    {:error, :file_not_found} = EtsHelper.get_partial(room_id, @partial_name, @offset)
+
+    EtsHelper.add_partial(table, @partial, @partial_name, @offset)
+
+    {:ok, @partial} = EtsHelper.get_partial(room_id, @partial_name, @offset)
+    {:error, :file_not_found} = EtsHelper.get_partial(room_id, @partial_name, @wrong_offset)
+    {:error, :file_not_found} = EtsHelper.get_partial(room_id, @wrong_partial_name, @offset)
+
+    EtsHelper.delete_partial(table, @partial_name, @offset)
+
+    {:error, :file_not_found} = EtsHelper.get_partial(room_id, @partial_name, @offset)
+  end
+
+  test "manifests managment", %{room_id: room_id, table: table} do
+    {:error, :file_not_found} = EtsHelper.get_manifest(room_id)
+    {:error, :file_not_found} = EtsHelper.get_delta_manifest(room_id)
+
+    EtsHelper.update_manifest(table, @manifest)
+
+    {:ok, @manifest} = EtsHelper.get_manifest(room_id)
+    {:error, :file_not_found} = EtsHelper.get_delta_manifest(room_id)
+
+    EtsHelper.update_delta_manifest(table, @delta_manifest)
+
+    {:ok, @manifest} = EtsHelper.get_manifest(room_id)
+    {:ok, @delta_manifest} = EtsHelper.get_delta_manifest(room_id)
+  end
+
+  test "recent partial managment", %{room_id: room_id, table: table} do
+    {:error, :file_not_found} = EtsHelper.get_recent_partial(room_id)
+    {:error, :file_not_found} = EtsHelper.get_delta_recent_partial(room_id)
+
+    EtsHelper.update_recent_partial(table, @recent_partial)
+
+    {:ok, @recent_partial} = EtsHelper.get_recent_partial(room_id)
+    {:error, :file_not_found} = EtsHelper.get_delta_recent_partial(room_id)
+
+    EtsHelper.update_delta_recent_partial(table, @delta_recent_partial)
+
+    {:ok, @recent_partial} = EtsHelper.get_recent_partial(room_id)
+    {:ok, @delta_recent_partial} = EtsHelper.get_delta_recent_partial(room_id)
+  end
+end

--- a/test/jellyfish/component/hls/ll_storage_test.exs
+++ b/test/jellyfish/component/hls/ll_storage_test.exs
@@ -1,0 +1,162 @@
+defmodule Jellyfish.Component.HLS.LLStorageTest do
+  @moduledoc false
+
+  use ExUnit.Case, async: true
+
+  alias Jellyfish.Component.HLS.{EtsHelper, LLStorage, RequestHandler}
+
+  @tmp_path "tmp/ll_storage"
+
+  @segment_name "segment"
+  @segment_content <<1, 2, 3>>
+
+  @partial_name "partial_segment"
+  @partial_content <<1, 2, 3, 4>>
+  @partial_sn {0, 0}
+
+  @manifest_name "manifest"
+  @manifest_content "manifest_content"
+
+  @delta_manifest_name "manifest_delta.m3u8"
+  @delta_manifest_content "delta_manifest_content"
+
+  @header_name "header"
+  @header_content <<1, 2, 3, 4, 5>>
+
+  setup_all do
+    File.mkdir_p!(@tmp_path)
+    on_exit(fn -> :file.del_dir_r(@tmp_path) end)
+  end
+
+  setup do
+    room_id = UUID.uuid4()
+    directory = Path.join(@tmp_path, room_id)
+
+    File.mkdir_p!(directory)
+
+    config = %LLStorage{directory: directory, room_id: room_id}
+
+    storage = LLStorage.init(config)
+    {:ok, _pid} = RequestHandler.start(room_id)
+
+    %{storage: storage, directory: directory, room_id: room_id}
+  end
+
+  test "store segment", %{storage: storage, directory: directory} do
+    {:ok, _storage} = store_segment(storage)
+
+    segment_path = Path.join(directory, @segment_name)
+    {:error, :enoent} = File.read(segment_path)
+  end
+
+  test "store partial", %{storage: storage, directory: directory, room_id: room_id} do
+    {:ok, _storage} = store_partial(storage)
+
+    partial_path = Path.join(directory, @partial_name)
+    {:ok, @partial_content} = File.read(partial_path)
+
+    {:ok, <<1, 2, 3, 4>>} = EtsHelper.get_partial(room_id, "partial_segment", 0)
+  end
+
+  test "store manifest", %{storage: storage, directory: directory, room_id: room_id} do
+    {:ok, storage} = store_partial(storage)
+    {:ok, _storage} = store_manifest(storage)
+
+    {:ok, @manifest_content} = EtsHelper.get_manifest(room_id)
+    {:ok, @partial_sn} = EtsHelper.get_recent_partial(room_id)
+
+    manifest_path = Path.join(directory, @manifest_name)
+    {:ok, @manifest_content} = File.read(manifest_path)
+
+    pid = self()
+
+    spawn(fn ->
+      RequestHandler.handle_manifest_request(room_id, @partial_sn)
+      send(pid, :manifest)
+    end)
+
+    assert_receive(:manifest)
+  end
+
+  test "store delta manifest", %{storage: storage, directory: directory, room_id: room_id} do
+    {:ok, storage} = store_partial(storage)
+    {:ok, _storage} = store_delta_manifest(storage)
+
+    {:ok, @delta_manifest_content} = EtsHelper.get_delta_manifest(room_id)
+    {:ok, @partial_sn} = EtsHelper.get_delta_recent_partial(room_id)
+
+    manifest_path = Path.join(directory, @delta_manifest_name)
+    {:ok, @delta_manifest_content} = File.read(manifest_path)
+
+    pid = self()
+
+    spawn(fn ->
+      RequestHandler.handle_delta_manifest_request(room_id, @partial_sn)
+      send(pid, :manifest)
+    end)
+
+    assert_receive(:manifest)
+  end
+
+  test "store header", %{storage: storage, directory: directory} do
+    {:ok, _storage} = store_header(storage)
+
+    header_path = Path.join(directory, @header_name)
+    {:ok, @header_content} = File.read(header_path)
+  end
+
+  defp store_segment(storage) do
+    LLStorage.store(
+      :parent_id,
+      @segment_name,
+      @segment_content,
+      :metadata,
+      %{mode: :binary, type: :segment},
+      storage
+    )
+  end
+
+  defp store_partial(storage) do
+    LLStorage.store(
+      :parent_id,
+      @partial_name,
+      @partial_content,
+      %{byte_offset: 0, sequence_number: 0},
+      %{mode: :binary, type: :partial_segment},
+      storage
+    )
+  end
+
+  defp store_manifest(storage) do
+    LLStorage.store(
+      :parent_id,
+      @manifest_name,
+      @manifest_content,
+      :metadata,
+      %{mode: :text, type: :manifest},
+      storage
+    )
+  end
+
+  defp store_delta_manifest(storage) do
+    LLStorage.store(
+      :parent_id,
+      @delta_manifest_name,
+      @delta_manifest_content,
+      :metadata,
+      %{mode: :text, type: :manifest},
+      storage
+    )
+  end
+
+  defp store_header(storage) do
+    LLStorage.store(
+      :parent_id,
+      @header_name,
+      @header_content,
+      :metadata,
+      %{mode: :binary, type: :header},
+      storage
+    )
+  end
+end

--- a/test/jellyfish/component/hls/ll_storage_test.exs
+++ b/test/jellyfish/component/hls/ll_storage_test.exs
@@ -5,8 +5,6 @@ defmodule Jellyfish.Component.HLS.LLStorageTest do
 
   alias Jellyfish.Component.HLS.{EtsHelper, LLStorage, RequestHandler}
 
-  @tmp_path "tmp/ll_storage"
-
   @segment_name "segment"
   @segment_content <<1, 2, 3>>
 
@@ -23,14 +21,9 @@ defmodule Jellyfish.Component.HLS.LLStorageTest do
   @header_name "header"
   @header_content <<1, 2, 3, 4, 5>>
 
-  setup_all do
-    File.mkdir_p!(@tmp_path)
-    on_exit(fn -> :file.del_dir_r(@tmp_path) end)
-  end
-
-  setup do
+  setup %{tmp_dir: tmp_dir} do
     room_id = UUID.uuid4()
-    directory = Path.join(@tmp_path, room_id)
+    directory = Path.join(tmp_dir, room_id)
 
     File.mkdir_p!(directory)
 
@@ -42,67 +35,67 @@ defmodule Jellyfish.Component.HLS.LLStorageTest do
     %{storage: storage, directory: directory, room_id: room_id}
   end
 
+  @tag :tmp_dir
   test "store segment", %{storage: storage, directory: directory} do
     {:ok, _storage} = store_segment(storage)
 
     segment_path = Path.join(directory, @segment_name)
-    {:error, :enoent} = File.read(segment_path)
+    assert {:error, :enoent} == File.read(segment_path)
   end
 
+  @tag :tmp_dir
   test "store partial", %{storage: storage, directory: directory, room_id: room_id} do
     {:ok, _storage} = store_partial(storage)
 
     partial_path = Path.join(directory, @partial_name)
-    {:ok, @partial_content} = File.read(partial_path)
+    assert {:ok, @partial_content} == File.read(partial_path)
 
-    {:ok, <<1, 2, 3, 4>>} = EtsHelper.get_partial(room_id, "partial_segment", 0)
+    assert {:ok, @partial_content} == EtsHelper.get_partial(room_id, @partial_name, 0)
   end
 
+  @tag :tmp_dir
   test "store manifest", %{storage: storage, directory: directory, room_id: room_id} do
     {:ok, storage} = store_partial(storage)
     {:ok, _storage} = store_manifest(storage)
 
-    {:ok, @manifest_content} = EtsHelper.get_manifest(room_id)
-    {:ok, @partial_sn} = EtsHelper.get_recent_partial(room_id)
+    assert {:ok, @manifest_content} == EtsHelper.get_manifest(room_id)
+    assert {:ok, @partial_sn} == EtsHelper.get_recent_partial(room_id)
 
     manifest_path = Path.join(directory, @manifest_name)
-    {:ok, @manifest_content} = File.read(manifest_path)
+    assert {:ok, @manifest_content} == File.read(manifest_path)
 
     pid = self()
 
     spawn(fn ->
-      RequestHandler.handle_manifest_request(room_id, @partial_sn)
+      {:ok, @manifest_content} = RequestHandler.handle_manifest_request(room_id, @partial_sn)
       send(pid, :manifest)
     end)
 
     assert_receive(:manifest)
   end
 
+  @tag :tmp_dir
+  @tag timeout: 1_000
   test "store delta manifest", %{storage: storage, directory: directory, room_id: room_id} do
     {:ok, storage} = store_partial(storage)
     {:ok, _storage} = store_delta_manifest(storage)
 
-    {:ok, @delta_manifest_content} = EtsHelper.get_delta_manifest(room_id)
-    {:ok, @partial_sn} = EtsHelper.get_delta_recent_partial(room_id)
+    assert {:ok, @delta_manifest_content} == EtsHelper.get_delta_manifest(room_id)
+    assert {:ok, @partial_sn} == EtsHelper.get_delta_recent_partial(room_id)
 
     manifest_path = Path.join(directory, @delta_manifest_name)
-    {:ok, @delta_manifest_content} = File.read(manifest_path)
+    assert {:ok, @delta_manifest_content} == File.read(manifest_path)
 
-    pid = self()
-
-    spawn(fn ->
-      RequestHandler.handle_delta_manifest_request(room_id, @partial_sn)
-      send(pid, :manifest)
-    end)
-
-    assert_receive(:manifest)
+    assert {:ok, @delta_manifest_content} ==
+             RequestHandler.handle_delta_manifest_request(room_id, @partial_sn)
   end
 
+  @tag :tmp_dir
   test "store header", %{storage: storage, directory: directory} do
     {:ok, _storage} = store_header(storage)
 
     header_path = Path.join(directory, @header_name)
-    {:ok, @header_content} = File.read(header_path)
+    assert {:ok, @header_content} == File.read(header_path)
   end
 
   defp store_segment(storage) do

--- a/test/jellyfish/component/hls/request_handler_test.exs
+++ b/test/jellyfish/component/hls/request_handler_test.exs
@@ -39,34 +39,34 @@ defmodule Jellyfish.Component.HLS.RequestHandlerTest do
     # wait for ets to be removed
     Process.sleep(200)
 
-    {:error, :room_not_found} = EtsHelper.get_manifest(room_id)
+    assert {:error, :room_not_found} == EtsHelper.get_manifest(room_id)
 
-    {:ok, _pid} = RequestHandler.start(room_id)
+    assert {:ok, _pid} = RequestHandler.start(room_id)
   end
 
   test "file request", %{room_id: room_id} do
     add_mock_manifest(room_id)
 
-    {:ok, @manifest_content} = RequestHandler.handle_file_request(room_id, @manifest)
+    assert {:ok, @manifest_content} == RequestHandler.handle_file_request(room_id, @manifest)
 
-    {:error, :enoent} = RequestHandler.handle_file_request(room_id, @wrong_manifest)
-    {:error, :enoent} = RequestHandler.handle_file_request(@wrong_room_id, @manifest)
+    assert {:error, :enoent} == RequestHandler.handle_file_request(room_id, @wrong_manifest)
+    assert {:error, :enoent} == RequestHandler.handle_file_request(@wrong_room_id, @manifest)
 
     remove_mock_manifest(room_id)
   end
 
   test "manifest request", %{room_id: room_id} do
-    {:error, :room_not_found} = RequestHandler.handle_manifest_request(room_id, @partial)
+    assert {:error, :room_not_found} == RequestHandler.handle_manifest_request(room_id, @partial)
 
     {:ok, table} = EtsHelper.add_room(room_id)
 
-    {:error, :file_not_found} = RequestHandler.handle_manifest_request(room_id, @partial)
+    assert {:error, :file_not_found} == RequestHandler.handle_manifest_request(room_id, @partial)
 
     EtsHelper.update_recent_partial(table, @partial)
     EtsHelper.update_manifest(table, @manifest_content)
     RequestHandler.update_recent_partial(room_id, @partial)
 
-    {:ok, @manifest_content} = RequestHandler.handle_manifest_request(room_id, @partial)
+    assert {:ok, @manifest_content} == RequestHandler.handle_manifest_request(room_id, @partial)
 
     pid = self()
 
@@ -83,17 +83,20 @@ defmodule Jellyfish.Component.HLS.RequestHandlerTest do
   end
 
   test "delta manifest request", %{room_id: room_id} do
-    {:error, :room_not_found} = RequestHandler.handle_delta_manifest_request(room_id, @partial)
+    assert {:error, :room_not_found} ==
+             RequestHandler.handle_delta_manifest_request(room_id, @partial)
 
     {:ok, table} = EtsHelper.add_room(room_id)
 
-    {:error, :file_not_found} = RequestHandler.handle_delta_manifest_request(room_id, @partial)
+    assert {:error, :file_not_found} ==
+             RequestHandler.handle_delta_manifest_request(room_id, @partial)
 
     EtsHelper.update_delta_recent_partial(table, @partial)
     EtsHelper.update_delta_manifest(table, @manifest_content)
     RequestHandler.update_delta_recent_partial(room_id, @partial)
 
-    {:ok, @manifest_content} = RequestHandler.handle_delta_manifest_request(room_id, @partial)
+    assert {:ok, @manifest_content} ==
+             RequestHandler.handle_delta_manifest_request(room_id, @partial)
 
     pid = self()
 
@@ -112,21 +115,21 @@ defmodule Jellyfish.Component.HLS.RequestHandlerTest do
   end
 
   test "partial request", %{room_id: room_id} do
-    {:error, :room_not_found} =
-      RequestHandler.handle_partial_request(room_id, @partial_name, @offset)
+    assert {:error, :room_not_found} ==
+             RequestHandler.handle_partial_request(room_id, @partial_name, @offset)
 
     {:ok, table} = EtsHelper.add_room(room_id)
 
-    {:error, :file_not_found} =
-      RequestHandler.handle_partial_request(room_id, @partial_name, @offset)
+    assert {:error, :file_not_found} ==
+             RequestHandler.handle_partial_request(room_id, @partial_name, @offset)
 
     EtsHelper.add_partial(table, @partial_content, @partial_name, @offset)
 
-    {:ok, @partial_content} =
-      RequestHandler.handle_partial_request(room_id, @partial_name, @offset)
+    assert {:ok, @partial_content} ==
+             RequestHandler.handle_partial_request(room_id, @partial_name, @offset)
 
-    {:error, :file_not_found} =
-      RequestHandler.handle_partial_request(room_id, @partial_name, @wrong_offset)
+    assert {:error, :file_not_found} ==
+             RequestHandler.handle_partial_request(room_id, @partial_name, @wrong_offset)
   end
 
   defp add_mock_manifest(room_id) do

--- a/test/jellyfish_web/controllers/hls_controller_test.exs
+++ b/test/jellyfish_web/controllers/hls_controller_test.exs
@@ -26,6 +26,8 @@ defmodule JellyfishWeb.HLSControllerTest do
   @offset 0
   @wrong_offset 50
 
+  @error_response "Not found"
+
   setup_all do
     output_path = HLS.output_dir(@room_id)
     File.mkdir_p!(output_path)
@@ -42,10 +44,10 @@ defmodule JellyfishWeb.HLSControllerTest do
     assert @master_manifest_content == response(conn1, 200)
 
     conn2 = get(conn, ~p"/hls/#{@wrong_room_id}/#{@master_manifest_name}")
-    response(conn2, 404)
+    assert @error_response == response(conn2, 404)
 
     conn3 = get(conn, ~p"/hls/#{@room_id}/wrong_name.m3u8")
-    response(conn3, 404)
+    assert @error_response == response(conn3, 404)
   end
 
   test "request header", %{conn: conn} do
@@ -53,10 +55,10 @@ defmodule JellyfishWeb.HLSControllerTest do
     assert @header_content == response(conn1, 200)
 
     conn2 = get(conn, ~p"/hls/#{@wrong_room_id}/#{@header_name}")
-    assert response(conn2, 404)
+    assert @error_response == response(conn2, 404)
 
     conn3 = get(conn, ~p"/hls/#{@room_id}/wrong_name.mp4")
-    assert response(conn3, 404)
+    assert @error_response == response(conn3, 404)
   end
 
   test "request segment", %{conn: conn} do
@@ -64,10 +66,10 @@ defmodule JellyfishWeb.HLSControllerTest do
     assert @segment_content == response(conn1, 200)
 
     conn2 = get(conn, ~p"/hls/#{@wrong_room_id}/#{@segment_name}")
-    assert response(conn2, 404)
+    assert @error_response == response(conn2, 404)
 
     conn3 = get(conn, ~p"/hls/#{@room_id}/wrong_name.m4s")
-    assert response(conn3, 404)
+    assert @error_response == response(conn3, 404)
   end
 
   test "request partial", %{conn: conn} do
@@ -83,19 +85,19 @@ defmodule JellyfishWeb.HLSControllerTest do
       |> put_req_header("range", "bytes=#{@wrong_offset}-100")
       |> get(~p"/hls/#{@room_id}/#{@partial_name}")
 
-    assert response(conn2, 404)
+    assert @error_response == response(conn2, 404)
 
     conn3 =
       conn
       |> get(~p"/hls/#{@wrong_room_id}/#{@partial_name}")
 
-    assert response(conn3, 404)
+    assert @error_response == response(conn3, 404)
 
     conn4 =
       conn
       |> get(~p"/hls/#{@room_id}/wrong_name.m4s")
 
-    assert response(conn4, 404)
+    assert @error_response == response(conn4, 404)
   end
 
   test "request manifest", %{conn: conn} do
@@ -103,10 +105,10 @@ defmodule JellyfishWeb.HLSControllerTest do
     assert @manifest_content == response(conn1, 200)
 
     conn2 = get(conn, ~p"/hls/#{@wrong_room_id}/#{@manifest_name}")
-    response(conn2, 404)
+    assert @error_response == response(conn2, 404)
 
     conn3 = get(conn, ~p"/hls/#{@room_id}/wrong_name.m3u8")
-    response(conn3, 404)
+    assert @error_response == response(conn3, 404)
   end
 
   test "request ll-manifest", %{conn: conn} do

--- a/test/jellyfish_web/controllers/hls_controller_test.exs
+++ b/test/jellyfish_web/controllers/hls_controller_test.exs
@@ -1,0 +1,165 @@
+defmodule JellyfishWeb.HLSControllerTest do
+  use JellyfishWeb.ConnCase, async: true
+
+  alias Jellyfish.Component.HLS
+  alias Jellyfish.Component.HLS.{EtsHelper, RequestHandler}
+
+  @room_id "hls_controller_test"
+  @wrong_room_id "wrong_id"
+
+  @header_name "header_name.mp4"
+  @header_content <<1>>
+
+  @segment_name "segment_name.m4s"
+  @segment_content <<2>>
+
+  @manifest_name "manifest_name.m3u8"
+  @manifest_content <<3>>
+  @delta_manifest_content <<4>>
+
+  @master_manifest_name "index.m3u8"
+  @master_manifest_content <<5>>
+
+  @partial_name "partial_name.m4s"
+  @partial_content <<6>>
+  @partial_sn {0, 0}
+  @offset 0
+  @wrong_offset 50
+
+  setup_all do
+    output_path = HLS.output_dir(@room_id)
+    File.mkdir_p!(output_path)
+
+    prepare_files(output_path)
+    prepare_ets()
+    prepare_request_handler()
+
+    on_exit(fn -> :file.del_dir_r(output_path) end)
+  end
+
+  test "request master manifest", %{conn: conn} do
+    conn1 = get(conn, ~p"/hls/#{@room_id}/#{@master_manifest_name}")
+    assert @master_manifest_content == response(conn1, 200)
+
+    conn2 = get(conn, ~p"/hls/#{@wrong_room_id}/#{@master_manifest_name}")
+    response(conn2, 404)
+
+    conn3 = get(conn, ~p"/hls/#{@room_id}/wrong_name.m3u8")
+    response(conn3, 404)
+  end
+
+  test "request header", %{conn: conn} do
+    conn1 = get(conn, ~p"/hls/#{@room_id}/#{@header_name}")
+    assert @header_content == response(conn1, 200)
+
+    conn2 = get(conn, ~p"/hls/#{@wrong_room_id}/#{@header_name}")
+    assert response(conn2, 404)
+
+    conn3 = get(conn, ~p"/hls/#{@room_id}/wrong_name.mp4")
+    assert response(conn3, 404)
+  end
+
+  test "request segment", %{conn: conn} do
+    conn1 = get(conn, ~p"/hls/#{@room_id}/#{@segment_name}")
+    assert @segment_content == response(conn1, 200)
+
+    conn2 = get(conn, ~p"/hls/#{@wrong_room_id}/#{@segment_name}")
+    assert response(conn2, 404)
+
+    conn3 = get(conn, ~p"/hls/#{@room_id}/wrong_name.m4s")
+    assert response(conn3, 404)
+  end
+
+  test "request partial", %{conn: conn} do
+    conn1 =
+      conn
+      |> put_req_header("range", "bytes=#{@offset}-100")
+      |> get(~p"/hls/#{@room_id}/#{@partial_name}")
+
+    assert @partial_content == response(conn1, 200)
+
+    conn2 =
+      conn
+      |> put_req_header("range", "bytes=#{@wrong_offset}-100")
+      |> get(~p"/hls/#{@room_id}/#{@partial_name}")
+
+    assert response(conn2, 404)
+
+    conn3 =
+      conn
+      |> get(~p"/hls/#{@wrong_room_id}/#{@partial_name}")
+
+    assert response(conn3, 404)
+
+    conn4 =
+      conn
+      |> get(~p"/hls/#{@room_id}/wrong_name.m4s")
+
+    assert response(conn4, 404)
+  end
+
+  test "request manifest", %{conn: conn} do
+    conn1 = get(conn, ~p"/hls/#{@room_id}/#{@manifest_name}")
+    assert @manifest_content == response(conn1, 200)
+
+    conn2 = get(conn, ~p"/hls/#{@wrong_room_id}/#{@manifest_name}")
+    response(conn2, 404)
+
+    conn3 = get(conn, ~p"/hls/#{@room_id}/wrong_name.m3u8")
+    response(conn3, 404)
+  end
+
+  test "request ll-manifest", %{conn: conn} do
+    conn1 =
+      get(conn, ~p"/hls/#{@room_id}/#{@manifest_name}", %{
+        "room_id" => @room_id,
+        "_HLS_msn" => 0,
+        "_HLS_part" => 0
+      })
+
+    assert @manifest_content == response(conn1, 200)
+  end
+
+  test "request ll-delta-manifest", %{conn: conn} do
+    conn =
+      get(conn, ~p"/hls/#{@room_id}/#{@manifest_name}", %{
+        "_HLS_skip" => true,
+        "room_id" => @room_id,
+        "_HLS_msn" => 0,
+        "_HLS_part" => 0
+      })
+
+    assert @delta_manifest_content == response(conn, 200)
+  end
+
+  defp prepare_files(output_path) do
+    header_path = Path.join(output_path, @header_name)
+    File.write!(header_path, @header_content)
+
+    manifest_path = Path.join(output_path, @manifest_name)
+    File.write!(manifest_path, @manifest_content)
+
+    segment_path = Path.join(output_path, @segment_name)
+    File.write!(segment_path, @segment_content)
+
+    master_manifest_path = Path.join(output_path, @master_manifest_name)
+    File.write!(master_manifest_path, @master_manifest_content)
+  end
+
+  defp prepare_ets() do
+    {:ok, table} = EtsHelper.add_room(@room_id)
+
+    EtsHelper.add_partial(table, @partial_content, @partial_name, @offset)
+    EtsHelper.update_recent_partial(table, @partial_sn)
+    EtsHelper.update_delta_recent_partial(table, @partial_sn)
+    EtsHelper.update_manifest(table, @manifest_content)
+    EtsHelper.update_delta_manifest(table, @delta_manifest_content)
+  end
+
+  defp prepare_request_handler() do
+    {:ok, _pid} = RequestHandler.start(@room_id)
+
+    RequestHandler.update_recent_partial(@room_id, @partial_sn)
+    RequestHandler.update_delta_recent_partial(@room_id, @partial_sn)
+  end
+end


### PR DESCRIPTION
This PR is part of a larger task of adding HLS to Jellyfish. In this PR there is an implementation of HLS Storage which is the only process that communicates with HLS Endpoint.

Here is a short introduction [doc](https://membraneframework.atlassian.net/wiki/spaces/MEMBRANEFR/pages/edit-v2/118063105?draftShareId=00bcc812-bfe6-4d45-abdb-7b264a91eea1&inEditorTemplatesPanel=auto_closed).