### PR TITLE
[RTC-345] Allow to configure HTTP endpoint IP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -96,6 +96,11 @@ WORKDIR /app
 # base path where jellyfish saves its artefacts
 ENV OUTPUT_BASE_PATH=./jellyfish_output
 
+# override default (127, 0, 0, 1) IP by 0.0.0.0 
+# as docker doesn't allow for connections outside the
+# container when we listen to 127.0.0.1
+ENV IP=0.0.0.0
+
 RUN mkdir ${OUTPUT_BASE_PATH} && chown jellyfish:jellyfish ${OUTPUT_BASE_PATH}
 
 COPY --from=build /app/_build/prod/rel/jellyfish ./

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -9,7 +9,7 @@ config :logger, level: :info
 
 # run the server automatically when using prod release
 config :jellyfish, JellyfishWeb.Endpoint,
-  http: [ip: {0, 0, 0, 0, 0, 0, 0, 0}, port: 8080],
+  http: [ip: {127, 0, 0, 1}, port: 8080],
   server: true
 
 # Runtime production configuration, including reading

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -58,6 +58,10 @@ if check_origin = ConfigReader.read_boolean("CHECK_ORIGIN") do
   config :jellyfish, JellyfishWeb.Endpoint, check_origin: check_origin
 end
 
+if ip = ConfigReader.read_ip("IP") do
+  config :jellyfish, JellyfishWeb.Endpoint, http: [ip: ip]
+end
+
 case System.get_env("SERVER_API_TOKEN") do
   nil when prod? == true ->
     raise """


### PR DESCRIPTION
We should by default bind to the 0.0.0.0 or 0.0.0.0.0.0.0.0 only when running in docker. When we run behind proxy it's better to run on a loopback not to accidentaly expose JF to the outside. 

We also allow for configuring this IP env so that everyone can run on whatever port they wish