### PR TITLE
[RTC-345] Prefix env vars with JF

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,19 +1,76 @@
-# used by the server e.g. to create tokens
-SECRET_KEY_BASE=super-secret-key
+# JF_IP and JF_PORT defines ip and port
+# our HTTP endpoint socket will listen to.
+# The default for Docker builds is 0.0.0.0 to allow 
+# access from the outside of container.
+# Note that this cannot be 127.0.0.1 as 
+# in Docker it only allows for traffic
+# from within the container.
+# For other builds, it is 127.0.0.1 not to 
+# accidentaly expose Jellyfish to the outside world
+# when it runs behind some proxy like nginx.
+# 
+# JF_IP=0.0.0.0
+# JF_PORT=5002
 
-# true, if WebRTC peers are used
-WEBRTC_USED=true
 
-# hostname used to generate URLs throught the server
-VIRTUAL_HOST=localhost
-PORT=5002
-SERVER_API_TOKEN=development
+# JF_HOST and JF_HOST_PORT defines how Jellyfish
+# should be seen from the outside.
+# When you run Jellyfish behind proxy, your
+# Jellyfish will run on 127.0.0.1 or 0.0.0.0
+# (see JF_IP and JF_PORT for more information)
+# but you don't want to and in fact you can't 
+# use those addresses for generating URLs, or 
+# telling Jellyfish Client to which server instance it 
+# should connect to (when running Jellyfish in a cluster).
+# That's why we have separate environment variables.
+#
+# Example
+#
+# You run Jellyfish on a machine with some public 
+# ip address `PUB_IP` and domain `DOMAIN`.
+# You most likely want to provide the following 
+# configuration when running Jellyfish using Docker
+# 
+# JF_HOST=$DOMAIN or $PUB_IP
+# JF_HOST_PORT=443
+# JF_IP = 0.0.0.0
+# JF_PORT = 5002
+# 
+# JF_IP and JF_PORT are set by default
+# so everything you need to set is JF_HOST and JF_HOST_PORT
+# 
+JF_HOST=localhost
+JF_HOST_PORT=443
+
+# JF_METRICS_IP=0.0.0.0
+# JF_METRICS_PORT=9568
+
+# Token used for authorizing HTTP requests
+JF_SERVER_API_TOKEN=jellyfish_docker_token
+
+# Used by the server e.g. to create client tokens.
+# If not set, it will be generated
+# JF_SECRET_KEY_BASE=super-secret-key
 
 # Decide if jellyfish will check origin of requests
-# CHECK_ORIGIN=false
+# JF_CHECK_ORIGIN=true
+
+# Where Jellyfish should save its artifacts
+# You can get access to this directory e.g. by mounting 
+# a volume with:
+#
+#   -v $(pwd)/jellyfish_output:/app/jellyfish_output 
+#
+# JF_OUTPUT_BASE_PATH=/app/jellyfish_output
+
+
+# WEBRTC ENVS
+
+# true, if WebRTC peers are used
+JF_WEBRTC_USED=true
 
 # TURN default configuration
 # note: loopback address as INTEGRATED_TURN_IP cannot be used inside a Docker container
-INTEGRATED_TURN_IP=<your_public_ip_address>
-INTEGRATED_TURN_LISTEN_IP=0.0.0.0
-INTEGRATED_TURN_PORT_RANGE=50000-65355
+JF_INTEGRATED_TURN_IP=<your_public_ip_address>
+JF_INTEGRATED_TURN_LISTEN_IP=0.0.0.0
+JF_INTEGRATED_TURN_PORT_RANGE=50000-59_999

--- a/.env.sample
+++ b/.env.sample
@@ -1,46 +1,15 @@
-# JF_IP and JF_PORT defines ip and port
-# our HTTP endpoint socket will listen to.
-# The default for Docker builds is 0.0.0.0 to allow 
-# access from the outside of container.
-# Note that this cannot be 127.0.0.1 as 
-# in Docker it only allows for traffic
-# from within the container.
-# For other builds, it is 127.0.0.1 not to 
-# accidentaly expose Jellyfish to the outside world
-# when it runs behind some proxy like nginx.
-# 
+# IP and PORT an HTTP endpoint will listen to
 # JF_IP=0.0.0.0
 # JF_PORT=5002
 
 
-# JF_HOST and JF_HOST_PORT defines how Jellyfish
-# should be seen from the outside.
-# When you run Jellyfish behind proxy, your
-# Jellyfish will run on 127.0.0.1 or 0.0.0.0
-# (see JF_IP and JF_PORT for more information)
-# but you don't want to and in fact you can't 
-# use those addresses for generating URLs, or 
-# telling Jellyfish Client to which server instance it 
-# should connect to (when running Jellyfish in a cluster).
-# That's why we have separate environment variables.
-#
-# Example
-#
-# You run Jellyfish on a machine with some public 
-# ip address `PUB_IP` and domain `DOMAIN`.
-# You most likely want to provide the following 
-# configuration when running Jellyfish using Docker
-# 
-# JF_HOST=$DOMAIN or $PUB_IP
-# JF_HOST_PORT=443
-# JF_IP = 0.0.0.0
-# JF_PORT = 5002
-# 
-# JF_IP and JF_PORT are set by default
-# so everything you need to set is JF_HOST and JF_HOST_PORT
-# 
-JF_HOST=localhost
-JF_HOST_PORT=443
+# Defines how Jellyfish is seen from the outside.
+# It can be in one of the following forms:
+# * ip:port
+# * fqdn:port
+# * fqdn
+# By default, it is equal to "JF_IP:JF_PORT".
+JF_HOST=localhost:5002
 
 # JF_METRICS_IP=0.0.0.0
 # JF_METRICS_PORT=9568
@@ -49,7 +18,7 @@ JF_HOST_PORT=443
 JF_SERVER_API_TOKEN=jellyfish_docker_token
 
 # Used by the server e.g. to create client tokens.
-# If not set, it will be generated
+# If not set, it will be generated.
 # JF_SECRET_KEY_BASE=super-secret-key
 
 # Decide if jellyfish will check origin of requests
@@ -71,6 +40,7 @@ JF_WEBRTC_USED=true
 
 # TURN default configuration
 # note: loopback address as INTEGRATED_TURN_IP cannot be used inside a Docker container
+# note: when running locally, JF_INTEGRATED_TURN_IP can be your private ip address 
 JF_INTEGRATED_TURN_IP=<your_public_ip_address>
 JF_INTEGRATED_TURN_LISTEN_IP=0.0.0.0
-JF_INTEGRATED_TURN_PORT_RANGE=50000-59_999
+JF_INTEGRATED_TURN_PORT_RANGE=50000-50050

--- a/.env.sample
+++ b/.env.sample
@@ -1,6 +1,7 @@
 # IP and PORT an HTTP endpoint will listen to
+# In Docker, JF_PORT defaults to 8080
 # JF_IP=0.0.0.0
-# JF_PORT=5002
+# JF_PORT=8080
 
 
 # Defines how Jellyfish is seen from the outside.
@@ -9,7 +10,7 @@
 # * fqdn:port
 # * fqdn
 # By default, it is equal to "JF_IP:JF_PORT".
-JF_HOST=localhost:5002
+JF_HOST=localhost:8080
 
 # JF_METRICS_IP=0.0.0.0
 # JF_METRICS_PORT=9568

--- a/Dockerfile
+++ b/Dockerfile
@@ -115,7 +115,7 @@ RUN chmod +x docker-entrypoint.sh
 
 ENV HOME=/app
 
-HEALTHCHECK CMD curl --fail -H "authorization: Bearer ${JF_SERVER_API_TOKEN}" http://localhost:${JF_PORT}/room || exit 1
+HEALTHCHECK CMD curl --fail -H "authorization: Bearer ${JF_SERVER_API_TOKEN}" http://localhost:${JF_PORT:-8080}/room || exit 1
 
 ENTRYPOINT ["./docker-entrypoint.sh"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -100,6 +100,11 @@ WORKDIR /app
 # base path where jellyfish saves its artefacts
 ENV OUTPUT_BASE_PATH=./jellyfish_output
 
+# override default (127, 0, 0, 1) IP by 0.0.0.0 
+# as docker doesn't allow for connections outside the
+# container when we listen to 127.0.0.1
+ENV IP=0.0.0.0
+
 RUN mkdir ${OUTPUT_BASE_PATH} && chown jellyfish:jellyfish ${OUTPUT_BASE_PATH}
 
 COPY --from=build /app/_build/prod/rel/jellyfish ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -98,14 +98,15 @@ RUN \
 WORKDIR /app
 
 # base path where jellyfish saves its artefacts
-ENV OUTPUT_BASE_PATH=./jellyfish_output
+ENV JF_OUTPUT_BASE_PATH=./jellyfish_output
 
 # override default (127, 0, 0, 1) IP by 0.0.0.0 
 # as docker doesn't allow for connections outside the
 # container when we listen to 127.0.0.1
 ENV JF_IP=0.0.0.0
+ENV JF_METRICS_IP=0.0.0.0
 
-RUN mkdir ${OUTPUT_BASE_PATH} && chown jellyfish:jellyfish ${OUTPUT_BASE_PATH}
+RUN mkdir ${JF_OUTPUT_BASE_PATH} && chown jellyfish:jellyfish ${JF_OUTPUT_BASE_PATH}
 
 COPY --from=build /app/_build/prod/rel/jellyfish ./
 
@@ -114,7 +115,7 @@ RUN chmod +x docker-entrypoint.sh
 
 ENV HOME=/app
 
-HEALTHCHECK CMD curl --fail -H "authorization: Bearer ${SERVER_API_TOKEN}" http://localhost:${PORT}/room || exit 1
+HEALTHCHECK CMD curl --fail -H "authorization: Bearer ${JF_SERVER_API_TOKEN}" http://localhost:${JF_PORT}/room || exit 1
 
 ENTRYPOINT ["./docker-entrypoint.sh"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -103,7 +103,7 @@ ENV OUTPUT_BASE_PATH=./jellyfish_output
 # override default (127, 0, 0, 1) IP by 0.0.0.0 
 # as docker doesn't allow for connections outside the
 # container when we listen to 127.0.0.1
-ENV IP=0.0.0.0
+ENV JF_IP=0.0.0.0
 
 RUN mkdir ${OUTPUT_BASE_PATH} && chown jellyfish:jellyfish ${OUTPUT_BASE_PATH}
 

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -9,7 +9,7 @@ config :logger, level: :info
 
 # run the server automatically when using prod release
 config :jellyfish, JellyfishWeb.Endpoint,
-  http: [ip: {0, 0, 0, 0, 0, 0, 0, 0}, port: 8080],
+  http: [ip: {127, 0, 0, 1}, port: 8080],
   server: true
 
 # Runtime production configuration, including reading

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -58,6 +58,10 @@ if check_origin = ConfigReader.read_boolean("CHECK_ORIGIN") do
   config :jellyfish, JellyfishWeb.Endpoint, check_origin: check_origin
 end
 
+if ip = ConfigReader.read_ip("IP") do
+  config :jellyfish, JellyfishWeb.Endpoint, http: [ip: ip]
+end
+
 case System.get_env("SERVER_API_TOKEN") do
   nil when prod? == true ->
     raise """

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -39,6 +39,12 @@ host =
     other -> other
   end
 
+host_port =
+  case ConfigReader.read_port("JF_HOST_PORT") do
+    nil -> port
+    other -> other
+  end
+
 config :jellyfish,
   webrtc_used: ConfigReader.read_boolean("JF_WEBRTC_USED") || true,
   integrated_turn_ip: ConfigReader.read_ip("JF_INTEGRATED_TURN_IP") || {127, 0, 0, 1},
@@ -49,14 +55,15 @@ config :jellyfish,
   integrated_turn_tcp_port: ConfigReader.read_port("JF_INTEGRATED_TURN_TCP_PORT"),
   jwt_max_age: 24 * 3600,
   output_base_path: System.get_env("JF_OUTPUT_BASE_PATH", "jellyfish_output") |> Path.expand(),
-  address: "#{host}:#{port}",
+  address: "#{host}:#{host_port}",
   metrics_ip: ConfigReader.read_ip("JF_METRICS_IP") || {127, 0, 0, 1},
   metrics_port: ConfigReader.read_port("JF_METRICS_PORT") || 9568
 
 config :jellyfish, JellyfishWeb.Endpoint,
   secret_key_base:
     System.get_env("JF_SECRET_KEY_BASE") || Base.encode64(:crypto.strong_rand_bytes(48)),
-  http: [ip: ip, port: port]
+  http: [ip: ip, port: port],
+  url: [host: host, port: host_port]
 
 if check_origin = ConfigReader.read_boolean("JF_CHECK_ORIGIN") do
   config :jellyfish, JellyfishWeb.Endpoint, check_origin: check_origin
@@ -78,5 +85,5 @@ case System.get_env("JF_SERVER_API_TOKEN") do
 end
 
 if prod? do
-  config :jellyfish, JellyfishWeb.Endpoint, url: [host: host, port: 443, scheme: "https"]
+  config :jellyfish, JellyfishWeb.Endpoint, url: [scheme: "https"]
 end

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -35,7 +35,7 @@ port =
 
 host =
   case System.get_env("JF_HOST") do
-    nil -> :inet.ntoa(ip)
+    nil -> :inet.ntoa(ip) |> to_string()
     other -> other
   end
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -11,62 +11,62 @@ alias Jellyfish.ConfigReader
 config :ex_dtls, impl: :nif
 config :opentelemetry, traces_exporter: :none
 
-hosts = ConfigReader.read_nodes("NODES")
+nodes = ConfigReader.read_nodes("JF_NODES")
 
-if hosts do
+if nodes do
   config :libcluster,
     topologies: [
       epmd_cluster: [
         strategy: Cluster.Strategy.Epmd,
-        config: [hosts: hosts]
+        config: [hosts: nodes]
       ]
     ]
 end
 
 prod? = config_env() == :prod
 
+ip =
+  ConfigReader.read_ip("JF_IP") ||
+    Application.get_env(:jellyfish, JellyfishWeb.Endpoint)[:http][:ip]
+
+port =
+  ConfigReader.read_port("JF_PORT") ||
+    Application.get_env(:jellyfish, JellyfishWeb.Endpoint)[:http][:port]
+
 host =
-  case System.get_env("HOST") do
-    nil when prod? -> raise "Unset HOST environment variable"
-    nil -> "localhost"
+  case System.get_env("JF_HOST") do
+    nil -> :inet.ntoa(ip)
     other -> other
   end
 
-port =
-  ConfigReader.read_port("PORT") ||
-    Application.get_env(:jellyfish, JellyfishWeb.Endpoint)[:http][:port]
-
 config :jellyfish,
-  webrtc_used: ConfigReader.read_boolean("WEBRTC_USED") || true,
-  integrated_turn_ip: ConfigReader.read_ip("INTEGRATED_TURN_IP") || {127, 0, 0, 1},
-  integrated_turn_listen_ip: ConfigReader.read_ip("INTEGRATED_TURN_LISTEN_IP") || {127, 0, 0, 1},
+  webrtc_used: ConfigReader.read_boolean("JF_WEBRTC_USED") || true,
+  integrated_turn_ip: ConfigReader.read_ip("JF_INTEGRATED_TURN_IP") || {127, 0, 0, 1},
+  integrated_turn_listen_ip:
+    ConfigReader.read_ip("JF_INTEGRATED_TURN_LISTEN_IP") || {127, 0, 0, 1},
   integrated_turn_port_range:
-    ConfigReader.read_port_range("INTEGRATED_TURN_PORT_RANGE") || {50_000, 59_999},
-  integrated_turn_tcp_port: ConfigReader.read_port("INTEGRATED_TURN_TCP_PORT"),
+    ConfigReader.read_port_range("JF_INTEGRATED_TURN_PORT_RANGE") || {50_000, 59_999},
+  integrated_turn_tcp_port: ConfigReader.read_port("JF_INTEGRATED_TURN_TCP_PORT"),
   jwt_max_age: 24 * 3600,
-  output_base_path: System.get_env("OUTPUT_BASE_PATH", "jellyfish_output") |> Path.expand(),
-  address: System.get_env("JELLYFISH_ADDRESS") || "#{host}:#{port}",
-  metrics_ip: ConfigReader.read_ip("METRICS_IP") || {127, 0, 0, 1},
-  metrics_port: ConfigReader.read_port("METRICS_PORT") || 9568
+  output_base_path: System.get_env("JF_OUTPUT_BASE_PATH", "jellyfish_output") |> Path.expand(),
+  address: "#{host}:#{port}",
+  metrics_ip: ConfigReader.read_ip("JF_METRICS_IP") || {127, 0, 0, 1},
+  metrics_port: ConfigReader.read_port("JF_METRICS_PORT") || 9568
 
 config :jellyfish, JellyfishWeb.Endpoint,
   secret_key_base:
-    System.get_env("SECRET_KEY_BASE") || Base.encode64(:crypto.strong_rand_bytes(48)),
-  http: [port: port]
+    System.get_env("JF_SECRET_KEY_BASE") || Base.encode64(:crypto.strong_rand_bytes(48)),
+  http: [ip: ip, port: port]
 
-if check_origin = ConfigReader.read_boolean("CHECK_ORIGIN") do
+if check_origin = ConfigReader.read_boolean("JF_CHECK_ORIGIN") do
   config :jellyfish, JellyfishWeb.Endpoint, check_origin: check_origin
 end
 
-if ip = ConfigReader.read_ip("IP") do
-  config :jellyfish, JellyfishWeb.Endpoint, http: [ip: ip]
-end
-
-case System.get_env("SERVER_API_TOKEN") do
+case System.get_env("JF_SERVER_API_TOKEN") do
   nil when prod? == true ->
     raise """
-    environment variable SERVER_API_TOKEN is missing.
-    SERVER_API_TOKEN is used for HTTP requests and
+    environment variable JF_SERVER_API_TOKEN is missing.
+    JF_SERVER_API_TOKEN is used for HTTP requests and
     server WebSocket authorization.
     """
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,7 +5,6 @@ x-jellyfish-template: &jellyfish-template
   environment: &jellyfish-environment
     ERLANG_COOKIE: "panuozzo-pollo-e-pancetta"
     JF_SERVER_API_TOKEN: "development"
-    JF_HOST: "localhost"
     JF_NODES: "app@app1 app@app2"
   networks:
     - net1
@@ -37,6 +36,7 @@ services:
       <<: *jellyfish-environment
       RELEASE_NODE: app@app1
       NODE_NAME: app@app1
+      JF_HOST: "localhost:4001"
       JF_PORT: 4001
     ports:
       - 4001:4001
@@ -47,6 +47,7 @@ services:
       <<: *jellyfish-environment
       RELEASE_NODE: app@app2
       NODE_NAME: app@app2
+      JF_HOST: "localhost:4002"
       JF_PORT: 4002
     ports:
       - 4002:4002

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,9 +4,9 @@ x-jellyfish-template: &jellyfish-template
   build: .
   environment: &jellyfish-environment
     ERLANG_COOKIE: "panuozzo-pollo-e-pancetta"
-    SERVER_API_TOKEN: "development"
-    HOST: "localhost"
-    NODES: "app@app1 app@app2"
+    JF_SERVER_API_TOKEN: "development"
+    JF_HOST: "localhost"
+    JF_NODES: "app@app1 app@app2"
   networks:
     - net1
   restart: on-failure
@@ -37,7 +37,7 @@ services:
       <<: *jellyfish-environment
       RELEASE_NODE: app@app1
       NODE_NAME: app@app1
-      PORT: 4001
+      JF_PORT: 4001
     ports:
       - 4001:4001
 
@@ -47,7 +47,7 @@ services:
       <<: *jellyfish-environment
       RELEASE_NODE: app@app2
       NODE_NAME: app@app2
-      PORT: 4002
+      JF_PORT: 4002
     ports:
       - 4002:4002
 


### PR DESCRIPTION
Let's follow good practices and perfix our env vars with `JF` not to overlap with other software. 

I also deleted `JELLYFISH_ADDRESS`. The idea is that `JF_HOST` is how we are seen by the others and it's used both for generating URLs and connecting to correct Jellyfish (i.e. address returned when we create a room).  


