### PR TITLE
[RTC-345] Introduce JF dedicated env vars for running in a distributed mode

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -25,7 +25,9 @@ JF_HOST=localhost:8080
 # JF_NODE_NAME=jellyfish1@127.0.0.1
 
 # Used for grouping Jellyfishes in a cluster
-# JF_COOKIE=jellyfishclustercookie
+# Use different cookies when you want to form 
+# multiple clusters running on shared machines.
+# JF_COOKIE=panuozzo-pollo-e-pancetta
 
 # List of other Jellyfishes we should try to connect to form a cluster
 # JF_NODES="jellyfish2@127.0.0.1 jellyfish3@127.0.0.1"

--- a/.env.sample
+++ b/.env.sample
@@ -40,7 +40,7 @@ JF_HOST=localhost:8080
 # Used for grouping Jellyfishes in a cluster
 # Use different cookies when you want to form 
 # multiple clusters running on shared machines.
-# JF_DIST_COOKIE=panuozzo-pollo-e-pancetta
+# JF_DIST_COOKIE=jellyfish_cookie
 
 # List of other Jellyfishes we should try to connect to form a cluster
 # JF_DIST_NODES="jellyfish2@127.0.0.1 jellyfish3@127.0.0.1"

--- a/.env.sample
+++ b/.env.sample
@@ -20,16 +20,16 @@ JF_HOST=localhost:8080
 
 # Node name used in a cluster.
 # The first part can be any string.
-# The second part has to be Jellyfish address # it is accessible on.
-# JF_NODE_NAME=jellyfish1@127.0.0.1
+# The second part has to be Jellyfish address it is accessible on.
+# JF_DIST_NODE_NAME=jellyfish1@127.0.0.1
 
 # Used for grouping Jellyfishes in a cluster
 # Use different cookies when you want to form 
 # multiple clusters running on shared machines.
-# JF_COOKIE=panuozzo-pollo-e-pancetta
+# JF_DIST_COOKIE=panuozzo-pollo-e-pancetta
 
 # List of other Jellyfishes we should try to connect to form a cluster
-# JF_NODES="jellyfish2@127.0.0.1 jellyfish3@127.0.0.1"
+# JF_DIST_NODES="jellyfish2@127.0.0.1 jellyfish3@127.0.0.1"
 
 # Ports used by Jellyfish when forming a cluster.
 # Besides them, Jellyfish also uses one more service
@@ -63,7 +63,7 @@ JF_WEBRTC_USED=true
 
 # TURN default configuration
 # note: loopback address as INTEGRATED_TURN_IP cannot be used inside a Docker container
-# note: when running locally, JF_INTEGRATED_TURN_IP can be your private ip address 
-JF_INTEGRATED_TURN_IP=<your_public_ip_address>
-JF_INTEGRATED_TURN_LISTEN_IP=0.0.0.0
-JF_INTEGRATED_TURN_PORT_RANGE=50000-50050
+# note: when running locally, JF_WEBRTC_TURN_IP can be your private ip address 
+JF_WEBRTC_TURN_IP=<your_public_ip_address>
+JF_WEBRTC_TURN_LISTEN_IP=0.0.0.0
+JF_WEBRTC_TURN_PORT_RANGE=50000-50050

--- a/.env.sample
+++ b/.env.sample
@@ -15,6 +15,21 @@ JF_HOST=localhost:8080
 # JF_METRICS_IP=0.0.0.0
 # JF_METRICS_PORT=9568
 
+# Defines whether to run Jellyfish in a cluster
+# JF_DIST_ENABLED=false
+
+# Node name used in a cluster.
+# The first part can be any string.
+# The second part has to be Jellyfish address
+# it is accessible on
+# JF_NODE_NAME=jellyfish1@127.0.0.1
+
+# Used for grouping Jellyfishes in a cluster
+# JF_COOKIE=jellyfishclustercookie
+
+# List of other Jellyfishes we should try to connect to form a cluster
+# JF_NODES="jellyfish2@127.0.0.1 jellyfish3@127.0.0.1"
+
 # Token used for authorizing HTTP requests
 JF_SERVER_API_TOKEN=jellyfish_docker_token
 

--- a/.env.sample
+++ b/.env.sample
@@ -48,6 +48,8 @@ JF_HOST=localhost:8080
 # Ports used by Jellyfish when forming a cluster.
 # Besides them, Jellyfish also uses one more service
 # called EPMD, which uses port 4369.
+# Note: those variables only take an effect in docker or
+# after doing `mix release`.
 # JF_DIST_MIN_PORT=9000
 # JF_DIST_MAX_PORT=9000
 

--- a/.env.sample
+++ b/.env.sample
@@ -19,9 +19,23 @@ JF_HOST=localhost:8080
 # JF_DIST_ENABLED=false
 
 # Node name used in a cluster.
-# The first part can be any string.
-# The second part has to be Jellyfish address it is accessible on.
+# It consists of two parts - nodename@hostname.
+# The first part identifies a node on a single machine and can
+# be any string.
+# The second part identifies the host machine and has to be an 
+# ip address or FQDN of a machine Jellyfish runs on.
+# If you run a cluster on a single machine or in the same docker network
+# and you don't want to use ip addresses or FQDN as hostnames, 
+# you can use short names (see JF_DIST_MODE).
 # JF_DIST_NODE_NAME=jellyfish1@127.0.0.1
+
+# Distribution mode - can be `name` or `sname`.
+# When using `name`, your hostname has to be 
+# an ip address or FQDN of a machine Jellyfish runs on.
+# When using `sname`, your hostname can be any string
+# See our docker-compose.yaml, which we use in our
+# integration tests for an example.
+# JF_DIST_MODE=name
 
 # Used for grouping Jellyfishes in a cluster
 # Use different cookies when you want to form 

--- a/.env.sample
+++ b/.env.sample
@@ -1,8 +1,9 @@
+## GENERAL ENVS ##
+
 # IP and PORT an HTTP endpoint will listen to
 # In Docker, JF_PORT defaults to 8080
 # JF_IP=0.0.0.0
 # JF_PORT=8080
-
 
 # Defines how Jellyfish is seen from the outside.
 # It can be in one of the following forms:
@@ -14,6 +15,26 @@ JF_HOST=localhost:8080
 
 # JF_METRICS_IP=0.0.0.0
 # JF_METRICS_PORT=9568
+
+# Token used for authorizing HTTP requests
+JF_SERVER_API_TOKEN=jellyfish_docker_token
+
+# Used by the server e.g. to create client tokens.
+# If not set, it will be generated.
+# JF_SECRET_KEY_BASE=super-secret-key
+
+# Decide if jellyfish will check origin of requests
+# JF_CHECK_ORIGIN=true
+
+# Where Jellyfish should save its artifacts
+# You can get access to this directory e.g. by mounting 
+# a volume with:
+#
+#   -v $(pwd)/jellyfish_output:/app/jellyfish_output 
+#
+# JF_OUTPUT_BASE_PATH=/app/jellyfish_output
+
+## DISTRIBUTION ENVS ##
 
 # Defines whether to run Jellyfish in a cluster
 # JF_DIST_ENABLED=false
@@ -53,26 +74,7 @@ JF_HOST=localhost:8080
 # JF_DIST_MIN_PORT=9000
 # JF_DIST_MAX_PORT=9000
 
-# Token used for authorizing HTTP requests
-JF_SERVER_API_TOKEN=jellyfish_docker_token
-
-# Used by the server e.g. to create client tokens.
-# If not set, it will be generated.
-# JF_SECRET_KEY_BASE=super-secret-key
-
-# Decide if jellyfish will check origin of requests
-# JF_CHECK_ORIGIN=true
-
-# Where Jellyfish should save its artifacts
-# You can get access to this directory e.g. by mounting 
-# a volume with:
-#
-#   -v $(pwd)/jellyfish_output:/app/jellyfish_output 
-#
-# JF_OUTPUT_BASE_PATH=/app/jellyfish_output
-
-
-# WEBRTC ENVS
+## WEBRTC ENVS ##
 
 # true, if WebRTC peers are used
 JF_WEBRTC_USED=true

--- a/.env.sample
+++ b/.env.sample
@@ -20,8 +20,7 @@ JF_HOST=localhost:8080
 
 # Node name used in a cluster.
 # The first part can be any string.
-# The second part has to be Jellyfish address
-# it is accessible on
+# The second part has to be Jellyfish address # it is accessible on.
 # JF_NODE_NAME=jellyfish1@127.0.0.1
 
 # Used for grouping Jellyfishes in a cluster

--- a/.env.sample
+++ b/.env.sample
@@ -30,6 +30,12 @@ JF_HOST=localhost:8080
 # List of other Jellyfishes we should try to connect to form a cluster
 # JF_NODES="jellyfish2@127.0.0.1 jellyfish3@127.0.0.1"
 
+# Ports used by Jellyfish when forming a cluster.
+# Besides them, Jellyfish also uses one more service
+# called EPMD, which uses port 4369.
+# JF_DIST_MIN_PORT=9000
+# JF_DIST_MAX_PORT=9000
+
 # Token used for authorizing HTTP requests
 JF_SERVER_API_TOKEN=jellyfish_docker_token
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,8 @@ ENV MIX_ENV=prod
 # but not deps fetching
 # * any changes in the `config/runtime.exs` won't trigger 
 # anything
+# * any changes in rel directory should only trigger
+# making a new release
 COPY mix.exs mix.lock ./
 RUN mix deps.get --only $MIX_ENV
 
@@ -42,6 +44,8 @@ COPY lib lib
 RUN mix compile
 
 COPY config/runtime.exs config/
+
+COPY rel rel
 
 RUN mix release
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -110,6 +110,9 @@ ENV JF_OUTPUT_BASE_PATH=./jellyfish_output
 ENV JF_IP=0.0.0.0
 ENV JF_METRICS_IP=0.0.0.0
 
+ENV JF_DIST_MIN_PORT=9000
+ENV JF_DIST_MAX_PORT=9000
+
 RUN mkdir ${JF_OUTPUT_BASE_PATH} && chown jellyfish:jellyfish ${JF_OUTPUT_BASE_PATH}
 
 COPY --from=build /app/_build/prod/rel/jellyfish ./

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -35,12 +35,11 @@ host =
 
 config :jellyfish,
   webrtc_used: ConfigReader.read_boolean("JF_WEBRTC_USED") || true,
-  integrated_turn_ip: ConfigReader.read_ip("JF_INTEGRATED_TURN_IP") || {127, 0, 0, 1},
-  integrated_turn_listen_ip:
-    ConfigReader.read_ip("JF_INTEGRATED_TURN_LISTEN_IP") || {127, 0, 0, 1},
+  integrated_turn_ip: ConfigReader.read_ip("JF_WEBRTC_TURN_IP") || {127, 0, 0, 1},
+  integrated_turn_listen_ip: ConfigReader.read_ip("JF_WEBRTC_TURN_LISTEN_IP") || {127, 0, 0, 1},
   integrated_turn_port_range:
-    ConfigReader.read_port_range("JF_INTEGRATED_TURN_PORT_RANGE") || {50_000, 59_999},
-  integrated_turn_tcp_port: ConfigReader.read_port("JF_INTEGRATED_TURN_TCP_PORT"),
+    ConfigReader.read_port_range("JF_WEBRTC_TURN_PORT_RANGE") || {50_000, 59_999},
+  integrated_turn_tcp_port: ConfigReader.read_port("JF_WEBRTC_TURN_TCP_PORT"),
   jwt_max_age: 24 * 3600,
   output_base_path: System.get_env("JF_OUTPUT_BASE_PATH", "jellyfish_output") |> Path.expand(),
   address: "#{host}",

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -11,18 +11,6 @@ alias Jellyfish.ConfigReader
 config :ex_dtls, impl: :nif
 config :opentelemetry, traces_exporter: :none
 
-nodes = ConfigReader.read_nodes("JF_NODES")
-
-if nodes do
-  config :libcluster,
-    topologies: [
-      epmd_cluster: [
-        strategy: Cluster.Strategy.Epmd,
-        config: [hosts: nodes]
-      ]
-    ]
-end
-
 prod? = config_env() == :prod
 
 ip =
@@ -57,7 +45,8 @@ config :jellyfish,
   output_base_path: System.get_env("JF_OUTPUT_BASE_PATH", "jellyfish_output") |> Path.expand(),
   address: "#{host}",
   metrics_ip: ConfigReader.read_ip("JF_METRICS_IP") || {127, 0, 0, 1},
-  metrics_port: ConfigReader.read_port("JF_METRICS_PORT") || 9568
+  metrics_port: ConfigReader.read_port("JF_METRICS_PORT") || 9568,
+  dist_config: ConfigReader.read_dist_config()
 
 case System.get_env("JF_SERVER_API_TOKEN") do
   nil when prod? == true ->

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,6 +5,7 @@ x-jellyfish-template: &jellyfish-template
   environment: &jellyfish-environment
     JF_SERVER_API_TOKEN: "development"
     JF_DIST_ENABLED: "true"
+    JF_DIST_MODE: "sname"
     JF_NODES: "app@app1 app@app2"
   networks:
     - net1

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,9 +3,10 @@ version: "3"
 x-jellyfish-template: &jellyfish-template
   build: .
   environment: &jellyfish-environment
-    ERLANG_COOKIE: "panuozzo-pollo-e-pancetta"
     JF_SERVER_API_TOKEN: "development"
+    JF_DIST_ENABLED: "true"
     JF_NODES: "app@app1 app@app2"
+    JF_COOKIE: "panuozzo-pollo-e-pancetta"
   networks:
     - net1
   restart: on-failure
@@ -34,10 +35,9 @@ services:
     <<: *jellyfish-template
     environment:
       <<: *jellyfish-environment
-      RELEASE_NODE: app@app1
-      NODE_NAME: app@app1
       JF_HOST: "localhost:4001"
       JF_PORT: 4001
+      JF_NODE_NAME: app@app1
     ports:
       - 4001:4001
 
@@ -45,10 +45,9 @@ services:
     <<: *jellyfish-template
     environment:
       <<: *jellyfish-environment
-      RELEASE_NODE: app@app2
-      NODE_NAME: app@app2
       JF_HOST: "localhost:4002"
       JF_PORT: 4002
+      JF_NODE_NAME: app@app2
     ports:
       - 4002:4002
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,7 +6,6 @@ x-jellyfish-template: &jellyfish-template
     JF_SERVER_API_TOKEN: "development"
     JF_DIST_ENABLED: "true"
     JF_NODES: "app@app1 app@app2"
-    JF_COOKIE: "panuozzo-pollo-e-pancetta"
   networks:
     - net1
   restart: on-failure

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,7 +6,7 @@ x-jellyfish-template: &jellyfish-template
     JF_SERVER_API_TOKEN: "development"
     JF_DIST_ENABLED: "true"
     JF_DIST_MODE: "sname"
-    JF_NODES: "app@app1 app@app2"
+    JF_DIST_NODES: "app@app1 app@app2"
   networks:
     - net1
   restart: on-failure
@@ -37,7 +37,7 @@ services:
       <<: *jellyfish-environment
       JF_HOST: "localhost:4001"
       JF_PORT: 4001
-      JF_NODE_NAME: app@app1
+      JF_DIST_NODE_NAME: app@app1
     ports:
       - 4001:4001
 
@@ -47,7 +47,7 @@ services:
       <<: *jellyfish-environment
       JF_HOST: "localhost:4002"
       JF_PORT: 4002
-      JF_NODE_NAME: app@app2
+      JF_DIST_NODE_NAME: app@app2
     ports:
       - 4002:4002
 

--- a/lib/jellyfish/application.ex
+++ b/lib/jellyfish/application.ex
@@ -5,38 +5,38 @@ defmodule Jellyfish.Application do
 
   use Application
 
+  require Logger
+
   @impl true
   def start(_type, _args) do
     scrape_interval = Application.fetch_env!(:jellyfish, :metrics_scrape_interval)
-
-    topologies = Application.get_env(:libcluster, :topologies) || []
-
-    children = [
-      {Phoenix.PubSub, name: Jellyfish.PubSub},
-      {Membrane.TelemetryMetrics.Reporter,
-       [
-         metrics: Membrane.RTC.Engine.Endpoint.WebRTC.Metrics.metrics(),
-         name: JellyfishMetricsReporter
-       ]},
-      {Jellyfish.MetricsScraper, scrape_interval},
-      JellyfishWeb.Endpoint,
-      # Start the RoomService
-      Jellyfish.RoomService,
-      {Registry, keys: :unique, name: Jellyfish.RoomRegistry},
-      {Registry, keys: :unique, name: Jellyfish.RequestHandlerRegistry},
-      # Start the Telemetry supervisor (must be started after Jellyfish.RoomRegistry)
-      JellyfishWeb.Telemetry,
-      {Task.Supervisor, name: Jellyfish.TaskSupervisor}
-    ]
-
-    :ets.new(:rooms_to_tables, [:public, :set, :named_table])
+    dist_config = Application.fetch_env!(:jellyfish, :dist_config)
 
     children =
-      if topologies == [] do
-        children
-      else
-        [{Cluster.Supervisor, [topologies, [name: Jellyfish.ClusterSupervisor]]} | children]
-      end
+      [
+        {Phoenix.PubSub, name: Jellyfish.PubSub},
+        {Membrane.TelemetryMetrics.Reporter,
+         [
+           metrics: Membrane.RTC.Engine.Endpoint.WebRTC.Metrics.metrics(),
+           name: JellyfishMetricsReporter
+         ]},
+        {Jellyfish.MetricsScraper, scrape_interval},
+        JellyfishWeb.Endpoint,
+        # Start the RoomService
+        Jellyfish.RoomService,
+        {Registry, keys: :unique, name: Jellyfish.RoomRegistry},
+        {Registry, keys: :unique, name: Jellyfish.RequestHandlerRegistry},
+        # Start the Telemetry supervisor (must be started after Jellyfish.RoomRegistry)
+        JellyfishWeb.Telemetry,
+        {Task.Supervisor, name: Jellyfish.TaskSupervisor}
+      ] ++
+        if dist_config[:enabled] do
+          config_distribution(dist_config)
+        else
+          []
+        end
+
+    :ets.new(:rooms_to_tables, [:public, :set, :named_table])
 
     # See https://hexdocs.pm/elixir/Supervisor.html
     # for other strategies and supported options
@@ -50,5 +50,51 @@ defmodule Jellyfish.Application do
   def config_change(changed, _new, removed) do
     JellyfishWeb.Endpoint.config_change(changed, removed)
     :ok
+  end
+
+  defp config_distribution(dist_config) do
+    ensure_epmd_started!()
+
+    # Release always starts in a distributed mode
+    # so we have to start a node only in development.
+    # See env.sh.eex for more information.
+    unless Node.alive?() do
+      case Node.start(dist_config[:node_name]) do
+        {:ok, _} ->
+          :ok
+
+        {:error, reason} ->
+          raise "Couldn't start Jellyfish node, reason: #{inspect(reason)}"
+      end
+
+      Node.set_cookie(dist_config[:cookie])
+    end
+
+    topologies = [
+      epmd_cluster: [
+        strategy: Cluster.Strategy.Epmd,
+        config: [hosts: dist_config[:nodes]]
+      ]
+    ]
+
+    [{Cluster.Supervisor, [topologies, [name: Jellyfish.ClusterSupervisor]]}]
+  end
+
+  defp ensure_epmd_started!() do
+    case System.cmd("epmd", ["-daemon"]) do
+      {_, 0} ->
+        :ok
+
+      _other ->
+        raise """
+        Couldn't start epmd daemon.
+        Epmd is required to run Jellyfish in a distributed mode.
+        You can try to start it manually with:
+          
+          epmd -daemon
+
+        and run Jellyfish again.
+        """
+    end
   end
 end

--- a/lib/jellyfish/config_reader.ex
+++ b/lib/jellyfish/config_reader.ex
@@ -1,6 +1,8 @@
 defmodule Jellyfish.ConfigReader do
   @moduledoc false
 
+  require Logger
+
   def read_port_range(env) do
     if value = System.get_env(env) do
       with [str1, str2] <- String.split(value, "-"),
@@ -48,19 +50,55 @@ defmodule Jellyfish.ConfigReader do
     end
   end
 
-  def read_nodes(env) do
-    value = System.get_env(env)
-
-    if value not in ["", nil] do
-      value
-      |> String.split(" ", trim: true)
-      |> Enum.map(&String.to_atom(&1))
-    end
-  end
-
   def read_boolean(env) do
     if value = System.get_env(env) do
       String.downcase(value) not in ["false", "f", "0"]
     end
+  end
+
+  def read_dist_config() do
+    if read_boolean("JF_DIST_ENABLED") do
+      node_name_value = System.get_env("JF_NODE_NAME")
+      cookie_value = System.get_env("JF_COOKIE")
+      nodes_value = System.get_env("JF_NODES") || ""
+
+      unset_var =
+        [{"JF_NODE_NAME", node_name_value}, {"JF_COOKIE", cookie_value}]
+        |> Enum.find(fn {_env_name, env_val} -> is_nil(env_val) end)
+
+      if unset_var do
+        {unset_var_name, _} = unset_var
+
+        raise """
+        JF_DIST_ENABLED has been set but #{unset_var_name} remains unset.
+        JF_DIST_ENABLED requires following env vars to be also set: JF_NODE_NAME JF_COOKIE.
+        """
+      end
+
+      node_name = parse_node_name(node_name_value)
+      cookie = parse_cookie(cookie_value)
+      nodes = parse_nodes(nodes_value)
+
+      if nodes == [] do
+        Logger.warning("""
+        JF_DIST_ENABLED has been set but JF_NODES remains unset.
+        Make sure that at least one of your Jellyfish instances
+        has JF_NODES set.
+        """)
+      end
+
+      [enabled: true, node_name: node_name, cookie: cookie, nodes: nodes]
+    else
+      [enabled: false, node_name: nil, cookie: nil, nodes: []]
+    end
+  end
+
+  defp parse_node_name(node_name), do: String.to_atom(node_name)
+  defp parse_cookie(cookie_value), do: String.to_atom(cookie_value)
+
+  defp parse_nodes(nodes_value) do
+    nodes_value
+    |> String.split(" ", trim: true)
+    |> Enum.map(&String.to_atom(&1))
   end
 end

--- a/lib/jellyfish/config_reader.ex
+++ b/lib/jellyfish/config_reader.ex
@@ -59,7 +59,7 @@ defmodule Jellyfish.ConfigReader do
   def read_dist_config() do
     if read_boolean("JF_DIST_ENABLED") do
       node_name_value = System.get_env("JF_DIST_NODE_NAME")
-      cookie_value = System.get_env("JF_DIST_COOKIE", "panuozzo-pollo-e-pancetta")
+      cookie_value = System.get_env("JF_DIST_COOKIE", "jellyfish_cookie")
       nodes_value = System.get_env("JF_DIST_NODES", "")
 
       unless node_name_value do

--- a/lib/jellyfish/config_reader.ex
+++ b/lib/jellyfish/config_reader.ex
@@ -58,12 +58,12 @@ defmodule Jellyfish.ConfigReader do
 
   def read_dist_config() do
     if read_boolean("JF_DIST_ENABLED") do
-      node_name_value = System.get_env("JF_NODE_NAME")
-      cookie_value = System.get_env("JF_COOKIE", "panuozzo-pollo-e-pancetta")
-      nodes_value = System.get_env("JF_NODES", "")
+      node_name_value = System.get_env("JF_DIST_NODE_NAME")
+      cookie_value = System.get_env("JF_DIST_COOKIE", "panuozzo-pollo-e-pancetta")
+      nodes_value = System.get_env("JF_DIST_NODES", "")
 
       unless node_name_value do
-        raise "JF_DIST_ENABLED has been set but JF_NODE_NAME remains unset."
+        raise "JF_DIST_ENABLED has been set but JF_DIST_NODE_NAME remains unset."
       end
 
       node_name = parse_node_name(node_name_value)
@@ -72,9 +72,9 @@ defmodule Jellyfish.ConfigReader do
 
       if nodes == [] do
         Logger.warning("""
-        JF_DIST_ENABLED has been set but JF_NODES remains unset.
+        JF_DIST_ENABLED has been set but JF_DIST_NODES remains unset.
         Make sure that at least one of your Jellyfish instances
-        has JF_NODES set.
+        has JF_DIST_NODES set.
         """)
       end
 

--- a/lib/jellyfish/config_reader.ex
+++ b/lib/jellyfish/config_reader.ex
@@ -59,20 +59,11 @@ defmodule Jellyfish.ConfigReader do
   def read_dist_config() do
     if read_boolean("JF_DIST_ENABLED") do
       node_name_value = System.get_env("JF_NODE_NAME")
-      cookie_value = System.get_env("JF_COOKIE")
-      nodes_value = System.get_env("JF_NODES") || ""
+      cookie_value = System.get_env("JF_COOKIE", "panuozzo-pollo-e-pancetta")
+      nodes_value = System.get_env("JF_NODES", "")
 
-      unset_var =
-        [{"JF_NODE_NAME", node_name_value}, {"JF_COOKIE", cookie_value}]
-        |> Enum.find(fn {_env_name, env_val} -> is_nil(env_val) end)
-
-      if unset_var do
-        {unset_var_name, _} = unset_var
-
-        raise """
-        JF_DIST_ENABLED has been set but #{unset_var_name} remains unset.
-        JF_DIST_ENABLED requires following env vars to be also set: JF_NODE_NAME JF_COOKIE.
-        """
+      unless node_name_value do
+        raise "JF_DIST_ENABLED has been set but JF_NODE_NAME remains unset."
       end
 
       node_name = parse_node_name(node_name_value)

--- a/rel/env.sh.eex
+++ b/rel/env.sh.eex
@@ -2,8 +2,8 @@
 # RELEASE_NODE and RELEASE_COOKIE.
 # This is to provide a unified way of configuring Jellyfish distribution
 # in both development and production environments
-export RELEASE_NODE=${JF_NODE_NAME:-${RELEASE_NODE:-jellyfish}}
-export RELEASE_COOKIE=${JF_COOKIE:-${RELEASE_COOKIE:-panuozzo-pollo-e-pancetta}}
+export RELEASE_NODE=${JF_DIST_NODE_NAME:-${RELEASE_NODE:-jellyfish}}
+export RELEASE_COOKIE=${JF_DIST_COOKIE:-${RELEASE_COOKIE:-panuozzo-pollo-e-pancetta}}
 
 # Use longnames by default.
 # They are required to form a cluster across diffrent machines.

--- a/rel/env.sh.eex
+++ b/rel/env.sh.eex
@@ -1,7 +1,33 @@
-# release always starts in a distributed mode
+# Release always starts in a distributed mode
 # but to provide unified way of configuring Jellyfish
 # distribution both in the local and production environment
 # we introduce our own env vars and use them to
-# set RELASE_NODE and RELASE_COOKIE
+# set RELASE_NODE and RELASE_COOKIE.
 export RELEASE_NODE=${JF_NODE_NAME:-${RELEASE_NODE:-jellyfish}}
 export RELEASE_COOKIE=${JF_COOKIE:-${RELEASE_COOKIE:-"$(cat "$RELEASE_ROOT/releases/COOKIE")"}}
+
+# We only set min and max ports for start and daemon commands.
+# In other case, when someone wants to expose only one port 
+# (JF_DIST_MIN_PORT==JF_DIST_MAX_PORT), we won't be able to 
+# connect to already running node with the `remote` command.
+if [ "$JF_DIST_MIN_PORT" != "" ] ; then
+    case $RELEASE_COMMAND in
+    start*|daemon*)
+        ELIXIR_ERL_OPTIONS="$ELIXIR_ERL_OPTIONS -kernel inet_dist_listen_min $JF_DIST_MIN_PORT"
+        export ELIXIR_ERL_OPTIONS
+        ;;
+    *)
+        ;;
+    esac
+fi
+
+if [ "$JF_DIST_MAX_PORT" != "" ] ; then
+    case $RELEASE_COMMAND in
+    start*|daemon*)
+        ELIXIR_ERL_OPTIONS="$ELIXIR_ERL_OPTIONS -kernel inet_dist_listen_max $JF_DIST_MAX_PORT"
+        export ELIXIR_ERL_OPTIONS
+        ;;
+    *)
+        ;;
+    esac
+fi

--- a/rel/env.sh.eex
+++ b/rel/env.sh.eex
@@ -1,8 +1,7 @@
-# Release always starts in a distributed mode
-# but to provide unified way of configuring Jellyfish
-# distribution both in the local and production environment
-# we introduce our own env vars and use them to
-# set RELASE_NODE and RELASE_COOKIE.
+# We introduce our own env vars and use them to set
+# RELEASE_NODE and RELEASE_COOKIE.
+# This is to provide a unified way of configuring Jellyfish distribution
+# in both development and production environments
 export RELEASE_NODE=${JF_NODE_NAME:-${RELEASE_NODE:-jellyfish}}
 export RELEASE_COOKIE=${JF_COOKIE:-${RELEASE_COOKIE:-panuozzo-pollo-e-pancetta}}
 

--- a/rel/env.sh.eex
+++ b/rel/env.sh.eex
@@ -3,7 +3,7 @@
 # This is to provide a unified way of configuring Jellyfish distribution
 # in both development and production environments
 export RELEASE_NODE=${JF_DIST_NODE_NAME:-${RELEASE_NODE:-jellyfish}}
-export RELEASE_COOKIE=${JF_DIST_COOKIE:-${RELEASE_COOKIE:-panuozzo-pollo-e-pancetta}}
+export RELEASE_COOKIE=${JF_DIST_COOKIE:-${RELEASE_COOKIE:-jellyfish_cookie}}
 
 # Use longnames by default.
 # They are required to form a cluster across diffrent machines.

--- a/rel/env.sh.eex
+++ b/rel/env.sh.eex
@@ -6,10 +6,10 @@
 export RELEASE_NODE=${JF_NODE_NAME:-${RELEASE_NODE:-jellyfish}}
 export RELEASE_COOKIE=${JF_COOKIE:-${RELEASE_COOKIE:-panuozzo-pollo-e-pancetta}}
 
-# Always use longnames.
+# Use longnames by default.
 # They are required to form a cluster across diffrent machines.
-# In development, we also use longnames (when starting a new node) 
-export RELEASE_DISTRIBUTION=name
+# In development, we also use longnames (when starting a new node).
+export RELEASE_DISTRIBUTION=${JF_DIST_MODE:-${RELEASE_DISTRIBUTION:-name}}
 
 # We only set min and max ports for start and daemon commands.
 # In other case, when someone wants to expose only one port 

--- a/rel/env.sh.eex
+++ b/rel/env.sh.eex
@@ -6,6 +6,11 @@
 export RELEASE_NODE=${JF_NODE_NAME:-${RELEASE_NODE:-jellyfish}}
 export RELEASE_COOKIE=${JF_COOKIE:-${RELEASE_COOKIE:-"$(cat "$RELEASE_ROOT/releases/COOKIE")"}}
 
+# Always use longnames.
+# They are required to form a cluster across diffrent machines.
+# In development, we also use longnames (when starting a new node) 
+export RELEASE_DISTRIBUTION=name
+
 # We only set min and max ports for start and daemon commands.
 # In other case, when someone wants to expose only one port 
 # (JF_DIST_MIN_PORT==JF_DIST_MAX_PORT), we won't be able to 

--- a/rel/env.sh.eex
+++ b/rel/env.sh.eex
@@ -4,7 +4,7 @@
 # we introduce our own env vars and use them to
 # set RELASE_NODE and RELASE_COOKIE.
 export RELEASE_NODE=${JF_NODE_NAME:-${RELEASE_NODE:-jellyfish}}
-export RELEASE_COOKIE=${JF_COOKIE:-${RELEASE_COOKIE:-"$(cat "$RELEASE_ROOT/releases/COOKIE")"}}
+export RELEASE_COOKIE=${JF_COOKIE:-${RELEASE_COOKIE:-panuozzo-pollo-e-pancetta}}
 
 # Always use longnames.
 # They are required to form a cluster across diffrent machines.

--- a/rel/env.sh.eex
+++ b/rel/env.sh.eex
@@ -1,0 +1,7 @@
+# release always starts in a distributed mode
+# but to provide unified way of configuring Jellyfish
+# distribution both in the local and production environment
+# we introduce our own env vars and use them to
+# set RELASE_NODE and RELASE_COOKIE
+export RELEASE_NODE=${JF_NODE_NAME:-${RELEASE_NODE:-jellyfish}}
+export RELEASE_COOKIE=${JF_COOKIE:-${RELEASE_COOKIE:-"$(cat "$RELEASE_ROOT/releases/COOKIE")"}}

--- a/test/jellyfish/config_reader_test.exs
+++ b/test/jellyfish/config_reader_test.exs
@@ -1,25 +1,32 @@
 defmodule Jellyfish.ConfigReaderTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
+
+  # run this test synchronously as we use
+  # official env vars in read_dist_config test
 
   alias Jellyfish.ConfigReader
 
   defmacrop with_env(env, do: body) do
-    # get current env value, 
+    # get current env(s) value(s), 
     # execute test code,
-    # put back original env value
+    # put back original env(s) value(s)
     #
     # if env was not set, we have
     # to call System.delete_env as
     # System.put_env does not accept `nil`
     quote do
-      old = System.get_env(unquote(env))
+      envs = List.wrap(unquote(env))
+      old_envs = Enum.map(envs, fn env_name -> {env_name, System.get_env(env_name)} end)
+
       unquote(body)
 
-      if old do
-        System.put_env(unquote(env), old)
-      else
-        System.delete_env(unquote(env))
-      end
+      Enum.each(old_envs, fn {env_name, env_value} ->
+        if env_value do
+          System.put_env(env_name, env_value)
+        else
+          System.delete_env(env_name)
+        end
+      end)
     end
   end
 
@@ -81,14 +88,36 @@ defmodule Jellyfish.ConfigReaderTest do
     end
   end
 
-  test "read_nodes/1" do
-    env_name = "JF_CONF_READER_TEST_NODES"
+  test "read_dist_config/0" do
+    with_env ["JF_DIST_ENABLED", "JF_COOKIE", "JF_NODE_NAME", "JF_NODES"] do
+      assert ConfigReader.read_dist_config() == [
+               enabled: false,
+               node_name: nil,
+               cookie: nil,
+               nodes: []
+             ]
 
-    with_env env_name do
-      System.put_env(env_name, "app1@127.0.0.1 app2@127.0.0.2")
-      assert ConfigReader.read_nodes(env_name) == [:"app1@127.0.0.1", :"app2@127.0.0.2"]
-      System.put_env(env_name, "")
-      assert ConfigReader.read_nodes(env_name) == nil
+      System.put_env("JF_DIST_ENABLED", "true")
+      assert_raise RuntimeError, fn -> ConfigReader.read_dist_config() end
+      System.put_env("JF_COOKIE", "testcookie")
+      assert_raise RuntimeError, fn -> ConfigReader.read_dist_config() end
+      System.put_env("JF_NODE_NAME", "testnodename@127.0.0.1")
+
+      assert ConfigReader.read_dist_config() == [
+               enabled: true,
+               node_name: :"testnodename@127.0.0.1",
+               cookie: :testcookie,
+               nodes: []
+             ]
+
+      System.put_env("JF_NODES", "testnodename1@127.0.0.1 testnodename2@127.0.0.1")
+
+      assert ConfigReader.read_dist_config() == [
+               enabled: true,
+               node_name: :"testnodename@127.0.0.1",
+               cookie: :testcookie,
+               nodes: [:"testnodename1@127.0.0.1", :"testnodename2@127.0.0.1"]
+             ]
     end
   end
 end

--- a/test/jellyfish/config_reader_test.exs
+++ b/test/jellyfish/config_reader_test.exs
@@ -89,7 +89,7 @@ defmodule Jellyfish.ConfigReaderTest do
   end
 
   test "read_dist_config/0" do
-    with_env ["JF_DIST_ENABLED", "JF_COOKIE", "JF_NODE_NAME", "JF_NODES"] do
+    with_env ["JF_DIST_ENABLED", "JF_DIST_COOKIE", "JF_DIST_NODE_NAME", "JF_DIST_NODES"] do
       assert ConfigReader.read_dist_config() == [
                enabled: false,
                node_name: nil,
@@ -99,9 +99,9 @@ defmodule Jellyfish.ConfigReaderTest do
 
       System.put_env("JF_DIST_ENABLED", "true")
       assert_raise RuntimeError, fn -> ConfigReader.read_dist_config() end
-      System.put_env("JF_COOKIE", "testcookie")
+      System.put_env("JF_DIST_COOKIE", "testcookie")
       assert_raise RuntimeError, fn -> ConfigReader.read_dist_config() end
-      System.put_env("JF_NODE_NAME", "testnodename@127.0.0.1")
+      System.put_env("JF_DIST_NODE_NAME", "testnodename@127.0.0.1")
 
       assert ConfigReader.read_dist_config() == [
                enabled: true,
@@ -110,7 +110,7 @@ defmodule Jellyfish.ConfigReaderTest do
                nodes: []
              ]
 
-      System.put_env("JF_NODES", "testnodename1@127.0.0.1 testnodename2@127.0.0.1")
+      System.put_env("JF_DIST_NODES", "testnodename1@127.0.0.1 testnodename2@127.0.0.1")
 
       assert ConfigReader.read_dist_config() == [
                enabled: true,


### PR DESCRIPTION
This PR introduces our own env variables for running JF in a cluster.

When we run erlang/elixir locally, we can setup distribution using flags like `--sname` `--name` `--cookie` etc. However, when we make a release, we are provided with special env variables e.g. `RELEASE_NODE` `RELEASE_COOKIE` etc. which results in multiple configuration options depending on environment we run Jellyfish in.

Intoducing our own env vars we:
* unify how JF is configured
* have better env names e.g. JF_COOKIE instead of strange RELEASE_COOKIE
* make **future** documentation easier to understand as our env vars are always available and always the same. RELEASE_* vars are only available after doing `mix release` so this would add unnecessary complexity in the documentation
* we also follow livebook behaviour, see this PR   https://github.com/livebook-dev/livebook/pull/1672