### PR TITLE
Raise when JF_DIST_NODE_NAME is not set in release mode

### DIFF
--- a/rel/env.sh.eex
+++ b/rel/env.sh.eex
@@ -3,8 +3,13 @@
 # This is to have a unified way of configuring Jellyfish distribution
 # in both development and production environments
 if [ "$JF_DIST_ENABLED" == "true" ]; then
-    export RELEASE_NODE=${JF_DIST_NODE_NAME:-${RELEASE_NODE:-jellyfish}}
+    export RELEASE_NODE=${JF_DIST_NODE_NAME:-$RELEASE_NODE}
     export RELEASE_COOKIE=${JF_DIST_COOKIE:-${RELEASE_COOKIE:-jellyfish_cookie}}
+
+    if [ "$RELEASE_NODE" == "" ]; then
+        echo "JF_DIST_ENABLED has been set but JF_DIST_NODE_NAME remains unset"
+        exit 1
+    fi
 
     # Use longnames by default.
     # They are required to form a cluster across diffrent machines.


### PR DESCRIPTION
We can't use `jellyfish` as default node name when we also use longnames as default distribution mode. Therefore it is better to just raise. That's also symmetric with the behavior when running from source