### PR TITLE
Fix OpenAPI summary for the recording endpoint

### DIFF
--- a/lib/jellyfish_web/controllers/recording_controller.ex
+++ b/lib/jellyfish_web/controllers/recording_controller.ex
@@ -31,7 +31,7 @@ defmodule JellyfishWeb.RecordingController do
 
   operation :show,
     operation_id: "get_recordings",
-    summary: "Shows information about the room",
+    summary: "Lists all available recordings",
     responses: [
       ok: ApiSpec.data("Success", ApiSpec.RecordingListResponse),
       not_found: ApiSpec.error("Unable to obtain recordings")
@@ -39,7 +39,7 @@ defmodule JellyfishWeb.RecordingController do
 
   operation :delete,
     operation_id: "delete_recording",
-    summary: "Delete the recording",
+    summary: "Deletes the recording",
     parameters: [recording_id: @recording_id_spec],
     responses: [
       no_content: %OpenApiSpex.Response{description: "Successfully deleted recording"},

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -468,7 +468,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: Unable to obtain recordings
-      summary: Shows information about the room
+      summary: Lists all available recordings
       tags:
         - recording
   /recording/{recording_id}:
@@ -491,7 +491,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: Recording doesn't exist
-      summary: Delete the recording
+      summary: Deletes the recording
       tags:
         - recording
   /recording/{recording_id}/{filename}:


### PR DESCRIPTION
I also feel like the `operationId` and `summary` for:
* `/hls/{room_id}/{filename}:`
* `/recording/{recording_id}/{filename}:`

could be improved?

## Acknowledging the stipulations set forth:
 - [x] I hereby confirm that a Pull Request involving updates to the Software Development Kit (SDK) has been smoothly merged, currently awaits processing, or is otherwise deemed unnecessary in this context.
 - [x] I also affirm that another Pull Request, specifically addressing updates to the documentation body (commonly referred to as 'docs'), has either been successfully incorporated, is in the process of review, or is considered superfluous under the prevailing circumstances.
