### PR TITLE
[RTC-379] Fix "list all rooms" test. Make RoomControllerTest sync.

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -8,7 +8,7 @@ config :jellyfish,
 # you can enable the server option below.
 config :jellyfish, JellyfishWeb.Endpoint,
   http: [ip: {127, 0, 0, 1}, port: 4002],
-  server: false
+  server: true
 
 # Print only warnings and errors during test
 config :logger, level: :warning

--- a/test/jellyfish_web/controllers/component_controller_test.exs
+++ b/test/jellyfish_web/controllers/component_controller_test.exs
@@ -39,8 +39,8 @@ defmodule JellyfishWeb.ComponentControllerTest do
 
   describe "create hls component" do
     test "renders component when data is valid, allows max 1 hls per room", %{conn: conn} do
-      room_conn = post(conn, ~p"/room", videoCodec: "h264")
-      assert %{"id" => room_id} = json_response(room_conn, :created)["data"]["room"]
+      conn = post(conn, ~p"/room", videoCodec: "h264")
+      assert %{"id" => room_id} = json_response(conn, :created)["data"]["room"]
 
       conn = post(conn, ~p"/room/#{room_id}/component", type: "hls")
 
@@ -78,14 +78,14 @@ defmodule JellyfishWeb.ComponentControllerTest do
       assert json_response(conn, :bad_request)["errors"] ==
                "Reached components limit in room #{room_id}"
 
-      room_conn = delete(conn, ~p"/room/#{room_id}")
-      assert response(room_conn, :no_content)
+      conn = delete(conn, ~p"/room/#{room_id}")
+      assert response(conn, :no_content)
       assert_no_hls_path(room_id)
     end
 
     test "renders component with peristent enabled", %{conn: conn} do
-      room_conn = post(conn, ~p"/room", videoCodec: "h264")
-      assert %{"id" => room_id} = json_response(room_conn, :created)["data"]["room"]
+      conn = post(conn, ~p"/room", videoCodec: "h264")
+      assert %{"id" => room_id} = json_response(conn, :created)["data"]["room"]
 
       conn = post(conn, ~p"/room/#{room_id}/component", type: "hls", options: %{persistent: true})
 
@@ -111,8 +111,8 @@ defmodule JellyfishWeb.ComponentControllerTest do
     end
 
     test "renders component with targetWindowDuration set", %{conn: conn} do
-      room_conn = post(conn, ~p"/room", videoCodec: "h264")
-      assert %{"id" => room_id} = json_response(room_conn, :created)["data"]["room"]
+      conn = post(conn, ~p"/room", videoCodec: "h264")
+      assert %{"id" => room_id} = json_response(conn, :created)["data"]["room"]
 
       conn =
         post(conn, ~p"/room/#{room_id}/component",
@@ -136,14 +136,14 @@ defmodule JellyfishWeb.ComponentControllerTest do
 
       assert_response_schema(response, "ComponentDetailsResponse", @schema)
 
-      room_conn = delete(conn, ~p"/room/#{room_id}")
-      assert response(room_conn, :no_content)
+      conn = delete(conn, ~p"/room/#{room_id}")
+      assert response(conn, :no_content)
       assert_no_hls_path(room_id)
     end
 
     test "renders component with ll-hls enabled", %{conn: conn} do
-      room_conn = post(conn, ~p"/room", videoCodec: "h264")
-      assert %{"id" => room_id} = json_response(room_conn, :created)["data"]["room"]
+      conn = post(conn, ~p"/room", videoCodec: "h264")
+      assert %{"id" => room_id} = json_response(conn, :created)["data"]["room"]
 
       assert Registry.lookup(Jellyfish.RequestHandlerRegistry, room_id) |> Enum.empty?()
 
@@ -178,8 +178,8 @@ defmodule JellyfishWeb.ComponentControllerTest do
       assert Process.alive?(request_handler)
       Process.monitor(engine_pid)
 
-      room_conn = delete(conn, ~p"/room/#{room_id}")
-      assert response(room_conn, :no_content)
+      conn = delete(conn, ~p"/room/#{room_id}")
+      assert response(conn, :no_content)
       assert_no_hls_path(room_id)
 
       # Engine can terminate up to around 5 seconds

--- a/test/jellyfish_web/controllers/component_controller_test.exs
+++ b/test/jellyfish_web/controllers/component_controller_test.exs
@@ -11,16 +11,17 @@ defmodule JellyfishWeb.ComponentControllerTest do
   setup %{conn: conn} do
     server_api_token = Application.fetch_env!(:jellyfish, :server_api_token)
     conn = put_req_header(conn, "authorization", "Bearer " <> server_api_token)
+    conn = put_req_header(conn, "accept", "application/json")
 
-    room_conn = post(conn, ~p"/room")
-    assert %{"id" => id} = json_response(room_conn, :created)["data"]["room"]
+    conn = post(conn, ~p"/room")
+    assert %{"id" => id} = json_response(conn, :created)["data"]["room"]
 
     on_exit(fn ->
-      room_conn = delete(conn, ~p"/room/#{id}")
-      assert response(room_conn, :no_content)
+      conn = delete(conn, ~p"/room/#{id}")
+      assert response(conn, :no_content)
     end)
 
-    {:ok, %{conn: put_req_header(conn, "accept", "application/json"), room_id: id}}
+    {:ok, %{conn: conn, room_id: id}}
   end
 
   describe "create component" do

--- a/test/jellyfish_web/controllers/peer_controller_test.exs
+++ b/test/jellyfish_web/controllers/peer_controller_test.exs
@@ -8,17 +8,21 @@ defmodule JellyfishWeb.PeerControllerTest do
 
   setup %{conn: conn} do
     server_api_token = Application.fetch_env!(:jellyfish, :server_api_token)
-    conn = put_req_header(conn, "authorization", "Bearer " <> server_api_token)
 
-    room_conn = post(conn, ~p"/room", maxPeers: 1)
-    assert %{"id" => id} = json_response(room_conn, :created)["data"]["room"]
+    conn =
+      conn
+      |> put_req_header("authorization", "Bearer " <> server_api_token)
+      |> put_req_header("accept", "application/json")
+
+    conn = post(conn, ~p"/room", maxPeers: 1)
+    assert %{"id" => id} = json_response(conn, :created)["data"]["room"]
 
     on_exit(fn ->
-      room_conn = delete(conn, ~p"/room/#{id}")
-      assert response(room_conn, :no_content)
+      conn = delete(conn, ~p"/room/#{id}")
+      assert response(conn, :no_content)
     end)
 
-    {:ok, %{conn: put_req_header(conn, "accept", "application/json"), room_id: id}}
+    {:ok, %{conn: conn, room_id: id}}
   end
 
   describe "create peer" do

--- a/test/jellyfish_web/controllers/room_controller_test.exs
+++ b/test/jellyfish_web/controllers/room_controller_test.exs
@@ -1,5 +1,5 @@
 defmodule JellyfishWeb.RoomControllerTest do
-  use JellyfishWeb.ConnCase
+  use JellyfishWeb.ConnCase, async: false
 
   import OpenApiSpex.TestAssertions
   alias Jellyfish.RoomService
@@ -9,6 +9,8 @@ defmodule JellyfishWeb.RoomControllerTest do
   setup %{conn: conn} do
     server_api_token = Application.fetch_env!(:jellyfish, :server_api_token)
     conn = put_req_header(conn, "authorization", "Bearer " <> server_api_token)
+
+    delete_all_rooms(conn)
 
     on_exit(fn -> delete_all_rooms(conn) end)
 
@@ -53,7 +55,12 @@ defmodule JellyfishWeb.RoomControllerTest do
 
   describe "index" do
     test "lists all rooms", %{conn: conn} do
+      conn = get(conn, ~p"/room")
+      response = json_response(conn, :ok)
+      assert Enum.empty?(response["data"])
+
       conn = post(conn, ~p"/room", maxPeers: 10)
+
       conn = get(conn, ~p"/room")
       response = json_response(conn, :ok)
       assert_response_schema(response, "RoomsListingResponse", @schema)

--- a/test/jellyfish_web/integration/server_notification_test.exs
+++ b/test/jellyfish_web/integration/server_notification_test.exs
@@ -265,7 +265,7 @@ defmodule JellyfishWeb.Integration.ServerNotificationTest do
     assert_receive %PeerConnected{peer_id: ^peer_id, room_id: ^room_id}
 
     subscribe(ws, :metrics)
-    assert_receive %MetricsReport{metrics: metrics} when metrics != "{}", 500
+    assert_receive %MetricsReport{metrics: metrics} when metrics != "{}", 1_000
 
     metrics = Jason.decode!(metrics)
 


### PR DESCRIPTION
## Acknowledging the stipulations set forth:
 - [ ] I hereby confirm that a Pull Request involving updates to the Software Development Kit (SDK) has been smoothly merged, currently awaits processing, or is otherwise deemed unnecessary in this context.
 - [ ] I also affirm that another Pull Request, specifically addressing updates to the documentation body (commonly referred to as 'docs'), has either been successfully incorporated, is in the process of review, or is considered superfluous under the prevailing circumstances.

This PR fixes two tests:
- Metrics notification tests by increasing timeouts because sometimes there was a situation that the notification wasn't received
- `list all rooms` test by disallowing parallel tests for this module and deleting all rooms before running any test case in this module. Previously, there was a possibility that there was another room in jellyfish before starting this test case.

In addition, in `component_controller_test.exs`, the naming for connection was unified, so in all test cases, we use the name `conn` instead of mixing `conn` and `room_conn`