### PR TITLE
HLS: subscribe for peers and components instead of specific tracks

### DIFF
--- a/lib/jellyfish/room.ex
+++ b/lib/jellyfish/room.ex
@@ -15,7 +15,6 @@ defmodule Jellyfish.Room do
 
   alias Membrane.ICE.TURNManager
   alias Membrane.RTC.Engine
-  alias Membrane.RTC.Engine.Track
 
   alias Membrane.RTC.Engine.Message.{
     EndpointAdded,
@@ -130,10 +129,10 @@ defmodule Jellyfish.Room do
     GenServer.call(registry_id(room_id), {:remove_component, component_id})
   end
 
-  @spec hls_subscribe(id(), [Track.id()]) ::
+  @spec hls_subscribe(id(), [Peer.id() | Component.id()]) ::
           :ok | {:error, term()}
-  def hls_subscribe(room_id, tracks) do
-    GenServer.call(registry_id(room_id), {:hls_subscribe, tracks})
+  def hls_subscribe(room_id, origins) do
+    GenServer.call(registry_id(room_id), {:hls_subscribe, origins})
   end
 
   @spec receive_media_event(id(), Peer.id(), String.t()) :: :ok
@@ -305,13 +304,13 @@ defmodule Jellyfish.Room do
   end
 
   @impl true
-  def handle_call({:hls_subscribe, tracks}, _from, state) do
+  def handle_call({:hls_subscribe, origins}, _from, state) do
     hls_component = hls_component(state)
 
     reply =
       case validate_hls_subscription(hls_component) do
         :ok ->
-          Engine.message_endpoint(state.engine_pid, hls_component.id, {:subscribe, tracks})
+          Engine.message_endpoint(state.engine_pid, hls_component.id, {:subscribe, origins})
 
         {:error, _reason} = error ->
           error

--- a/lib/jellyfish_web/api_spec/subscription.ex
+++ b/lib/jellyfish_web/api_spec/subscription.ex
@@ -3,20 +3,7 @@ defmodule JellyfishWeb.ApiSpec.Subscription do
 
   alias OpenApiSpex.Schema
 
-  defmodule Origin do
-    @moduledoc false
-
-    require OpenApiSpex
-
-    OpenApiSpex.schema(%{
-      title: "Origin",
-      description: "Component or Peer id",
-      type: :string,
-      example: "peer-id"
-    })
-  end
-
-  defmodule Tracks do
+  defmodule Origins do
     @moduledoc false
 
     require OpenApiSpex
@@ -29,8 +16,8 @@ defmodule JellyfishWeb.ApiSpec.Subscription do
         origins: %Schema{
           type: :array,
           description:
-            "List of peers and components whose tracks the HLS endpoint will subscribe to",
-          items: Origin
+            "List of peers and components ids whose tracks the HLS endpoint will subscribe to",
+          items: %OpenApiSpex.Schema{type: :string}
         }
       }
     })

--- a/lib/jellyfish_web/api_spec/subscription.ex
+++ b/lib/jellyfish_web/api_spec/subscription.ex
@@ -3,16 +3,16 @@ defmodule JellyfishWeb.ApiSpec.Subscription do
 
   alias OpenApiSpex.Schema
 
-  defmodule Track do
+  defmodule Origin do
     @moduledoc false
 
     require OpenApiSpex
 
     OpenApiSpex.schema(%{
-      title: "Track",
-      description: "Track id",
+      title: "Origin",
+      description: "Component or Peer id",
       type: :string,
-      example: "track-1"
+      example: "peer-id"
     })
   end
 
@@ -26,10 +26,11 @@ defmodule JellyfishWeb.ApiSpec.Subscription do
       description: "Subscription config",
       type: :object,
       properties: %{
-        tracks: %Schema{
+        origins: %Schema{
           type: :array,
-          description: "List of tracks that hls endpoint will subscribe for",
-          items: Track
+          description:
+            "List of peers and components whose tracks the HLS endpoint will subscribe to",
+          items: Origin
         }
       }
     })

--- a/lib/jellyfish_web/controllers/subscription_controller.ex
+++ b/lib/jellyfish_web/controllers/subscription_controller.ex
@@ -15,7 +15,7 @@ defmodule JellyfishWeb.SubscriptionController do
     operation_id: "subscribe_hls_to",
     summary: "Subscribe the HLS component to the tracks of peers or components",
     parameters: [room_id: [in: :path, description: "Room ID", type: :string]],
-    request_body: {"Subscribe configuration", "application/json", ApiSpec.Subscription.Origin},
+    request_body: {"Subscribe configuration", "application/json", ApiSpec.Subscription.Origins},
     responses: [
       created: %Response{description: "Tracks succesfully added."},
       bad_request: ApiSpec.error("Invalid request structure"),
@@ -23,7 +23,7 @@ defmodule JellyfishWeb.SubscriptionController do
     ]
 
   def create(conn, %{"room_id" => room_id} = params) do
-    with origins <- Map.get(params, "origins", %{}),
+    with {:ok, origins} <- Map.fetch(params, "origins"),
          {:ok, _room_pid} <- RoomService.find_room(room_id),
          :ok <- Room.hls_subscribe(room_id, origins) do
       send_resp(conn, :created, "Successfully subscribed for tracks")

--- a/lib/jellyfish_web/controllers/subscription_controller.ex
+++ b/lib/jellyfish_web/controllers/subscription_controller.ex
@@ -12,10 +12,10 @@ defmodule JellyfishWeb.SubscriptionController do
   tags [:hls]
 
   operation :create,
-    operation_id: "subscribe_tracks",
-    summary: "Subscribe hls component for tracks",
+    operation_id: "subscribe_hls_to",
+    summary: "Subscribe the HLS component to the tracks of peers or components",
     parameters: [room_id: [in: :path, description: "Room ID", type: :string]],
-    request_body: {"Subscribe configuration", "application/json", ApiSpec.Subscription.Tracks},
+    request_body: {"Subscribe configuration", "application/json", ApiSpec.Subscription.Origin},
     responses: [
       created: %Response{description: "Tracks succesfully added."},
       bad_request: ApiSpec.error("Invalid request structure"),
@@ -23,9 +23,9 @@ defmodule JellyfishWeb.SubscriptionController do
     ]
 
   def create(conn, %{"room_id" => room_id} = params) do
-    with tracks <- Map.get(params, "tracks", %{}),
+    with origins <- Map.get(params, "origins", %{}),
          {:ok, _room_pid} <- RoomService.find_room(room_id),
-         :ok <- Room.hls_subscribe(room_id, tracks) do
+         :ok <- Room.hls_subscribe(room_id, origins) do
       send_resp(conn, :created, "Successfully subscribed for tracks")
     else
       :error ->

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5,25 +5,126 @@
 components:
   responses: {}
   schemas:
-    PeerStatus:
-      description: Informs about the peer status
-      enum:
-        - connected
-        - disconnected
-      example: disconnected
-      title: PeerStatus
+    AuthToken:
+      description: Token for authorizing websocket connection
+      example: 5cdac726-57a3-4ecb-b1d5-72a3d62ec242
+      title: AuthToken
       type: string
-      x-struct: Elixir.JellyfishWeb.ApiSpec.Peer.Status
-    RoomDetailsResponse:
-      description: Response containing room details
+      x-struct: Elixir.JellyfishWeb.ApiSpec.Peer.Token
+    Component:
+      description: Describes component
+      discriminator:
+        mapping:
+          file: '#/components/schemas/ComponentFile'
+          hls: '#/components/schemas/ComponentHLS'
+          rtsp: '#/components/schemas/ComponentRTSP'
+        propertyName: type
+      oneOf:
+        - $ref: '#/components/schemas/ComponentHLS'
+        - $ref: '#/components/schemas/ComponentRTSP'
+        - $ref: '#/components/schemas/ComponentFile'
+      title: Component
+      type: object
+      x-struct: Elixir.JellyfishWeb.ApiSpec.Component
+    ComponentDetailsResponse:
+      description: Response containing component details
       properties:
         data:
-          $ref: '#/components/schemas/Room'
+          $ref: '#/components/schemas/Component'
       required:
         - data
-      title: RoomDetailsResponse
+      title: ComponentDetailsResponse
       type: object
-      x-struct: Elixir.JellyfishWeb.ApiSpec.RoomDetailsResponse
+      x-struct: Elixir.JellyfishWeb.ApiSpec.ComponentDetailsResponse
+    ComponentFile:
+      description: Describes the File component
+      properties:
+        id:
+          description: Assigned component ID
+          example: component-1
+          type: string
+        type:
+          description: Component type
+          example: file
+          type: string
+      required:
+        - id
+        - type
+      title: ComponentFile
+      type: object
+      x-struct: Elixir.JellyfishWeb.ApiSpec.Component.File
+    ComponentHLS:
+      description: Describes the HLS component
+      properties:
+        id:
+          description: Assigned component ID
+          example: component-1
+          type: string
+        properties:
+          $ref: '#/components/schemas/ComponentPropertiesHLS'
+        type:
+          description: Component type
+          example: hls
+          type: string
+      required:
+        - id
+        - type
+        - properties
+      title: ComponentHLS
+      type: object
+      x-struct: Elixir.JellyfishWeb.ApiSpec.Component.HLS
+    ComponentOptions:
+      description: Component-specific options
+      oneOf:
+        - $ref: '#/components/schemas/ComponentOptionsHLS'
+        - $ref: '#/components/schemas/ComponentOptionsRTSP'
+        - $ref: '#/components/schemas/ComponentOptionsFile'
+      title: ComponentOptions
+      type: object
+      x-struct: Elixir.JellyfishWeb.ApiSpec.Component.Options
+    ComponentOptionsFile:
+      description: Options specific to the File component
+      properties:
+        filePath:
+          description: Path to track file. Must be either OPUS encapsulated in Ogg or raw h264
+          example: /root/video.h264
+          type: string
+      required:
+        - filePath
+      title: ComponentOptionsFile
+      type: object
+      x-struct: Elixir.JellyfishWeb.ApiSpec.Component.File.Options
+    ComponentOptionsHLS:
+      description: Options specific to the HLS component
+      properties:
+        lowLatency:
+          default: false
+          description: Whether the component should use LL-HLS
+          type: boolean
+        persistent:
+          default: false
+          description: Whether the video is stored after end of stream
+          type: boolean
+        s3:
+          description: Credentials to AWS S3 bucket.
+          nullable: true
+          oneOf:
+            - $ref: '#/components/schemas/S3Credentials'
+          type: object
+        subscribeMode:
+          default: auto
+          description: Whether the HLS component should subscribe to tracks automatically or manually.
+          enum:
+            - auto
+            - manual
+          type: string
+        targetWindowDuration:
+          description: Duration of stream available for viewer
+          nullable: true
+          type: integer
+      title: ComponentOptionsHLS
+      type: object
+      x-struct: Elixir.JellyfishWeb.ApiSpec.Component.HLS.Options
     ComponentOptionsRTSP:
       description: Options specific to the RTSP component
       properties:
@@ -87,6 +188,139 @@ components:
       title: ComponentPropertiesHLS
       type: object
       x-struct: Elixir.JellyfishWeb.ApiSpec.Component.HLS.Properties
+    ComponentPropertiesRTSP:
+      description: Properties specific to the RTSP component
+      properties: {}
+      title: ComponentPropertiesRTSP
+      type: object
+      x-struct: Elixir.JellyfishWeb.ApiSpec.Component.RTSP.Properties
+    ComponentRTSP:
+      description: Describes the RTSP component
+      properties:
+        id:
+          description: Assigned component ID
+          example: component-1
+          type: string
+        properties:
+          $ref: '#/components/schemas/ComponentPropertiesRTSP'
+        type:
+          description: Component type
+          example: hls
+          type: string
+      required:
+        - id
+        - type
+        - properties
+      title: ComponentRTSP
+      type: object
+      x-struct: Elixir.JellyfishWeb.ApiSpec.Component.RTSP
+    ComponentType:
+      description: Component type
+      example: hls
+      title: ComponentType
+      type: string
+      x-struct: Elixir.JellyfishWeb.ApiSpec.Component.Type
+    Error:
+      description: Error message
+      properties:
+        errors:
+          description: Error details
+          example: Token has expired
+          type: string
+      required:
+        - errors
+      title: Error
+      type: object
+      x-struct: Elixir.JellyfishWeb.ApiSpec.Error
+    HlsMsn:
+      description: Segment sequence number
+      example: 10
+      minimum: 0
+      nullable: true
+      title: HlsMsn
+      type: integer
+      x-struct: Elixir.JellyfishWeb.ApiSpec.HLS.Params.HlsMsn
+    HlsPart:
+      description: Partial segment sequence number
+      example: 10
+      minimum: 0
+      nullable: true
+      title: HlsPart
+      type: integer
+      x-struct: Elixir.JellyfishWeb.ApiSpec.HLS.Params.HlsPart
+    HlsResponse:
+      description: Requested file
+      title: HlsResponse
+      type: string
+      x-struct: Elixir.JellyfishWeb.ApiSpec.HLS.Response
+    HlsSkip:
+      description: Is delta manifest requested
+      enum:
+        - YES
+      example: YES
+      nullable: true
+      title: HlsSkip
+      type: string
+      x-struct: Elixir.JellyfishWeb.ApiSpec.HLS.Params.HlsSkip
+    Peer:
+      description: Peer id
+      example: peer-id
+      title: Peer
+      type: string
+      x-struct: Elixir.JellyfishWeb.ApiSpec.Subscription.Peer
+    PeerDetailsResponse:
+      description: Response containing peer details and their token
+      properties:
+        data:
+          properties:
+            peer:
+              $ref: '#/components/schemas/Peer'
+            token:
+              $ref: '#/components/schemas/AuthToken'
+          required:
+            - peer
+            - token
+          type: object
+      required:
+        - data
+      title: PeerDetailsResponse
+      type: object
+      x-struct: Elixir.JellyfishWeb.ApiSpec.PeerDetailsResponse
+    PeerOptions:
+      description: Peer-specific options
+      oneOf:
+        - $ref: '#/components/schemas/PeerOptionsWebRTC'
+      title: PeerOptions
+      type: object
+      x-struct: Elixir.JellyfishWeb.ApiSpec.Peer.Options
+    PeerOptionsWebRTC:
+      description: Options specific to the WebRTC peer
+      properties:
+        enableSimulcast:
+          default: true
+          description: Enables the peer to use simulcast
+          type: boolean
+      title: PeerOptionsWebRTC
+      type: object
+      x-struct: Elixir.JellyfishWeb.ApiSpec.Peer.WebRTC
+    PeerType:
+      description: Peer type
+      example: webrtc
+      title: PeerType
+      type: string
+      x-struct: Elixir.JellyfishWeb.ApiSpec.Peer.Type
+    RecordingListResponse:
+      description: Response containing list of all recording
+      properties:
+        data:
+          items:
+            type: string
+          type: array
+      required:
+        - data
+      title: RecordingListResponse
+      type: object
+      x-struct: Elixir.JellyfishWeb.ApiSpec.RecordingListResponse
     Room:
       description: Description of the room state
       properties:
@@ -112,343 +346,6 @@ components:
       title: Room
       type: object
       x-struct: Elixir.JellyfishWeb.ApiSpec.Room
-    Component:
-      description: Describes component
-      discriminator:
-        mapping:
-          file: '#/components/schemas/ComponentFile'
-          hls: '#/components/schemas/ComponentHLS'
-          rtsp: '#/components/schemas/ComponentRTSP'
-        propertyName: type
-      oneOf:
-        - $ref: '#/components/schemas/ComponentHLS'
-        - $ref: '#/components/schemas/ComponentRTSP'
-        - $ref: '#/components/schemas/ComponentFile'
-      title: Component
-      type: object
-      x-struct: Elixir.JellyfishWeb.ApiSpec.Component
-    PeerOptionsWebRTC:
-      description: Options specific to the WebRTC peer
-      properties:
-        enableSimulcast:
-          default: true
-          description: Enables the peer to use simulcast
-          type: boolean
-      title: PeerOptionsWebRTC
-      type: object
-      x-struct: Elixir.JellyfishWeb.ApiSpec.Peer.WebRTC
-    ComponentHLS:
-      description: Describes the HLS component
-      properties:
-        id:
-          description: Assigned component ID
-          example: component-1
-          type: string
-        properties:
-          $ref: '#/components/schemas/ComponentPropertiesHLS'
-        type:
-          description: Component type
-          example: hls
-          type: string
-      required:
-        - id
-        - type
-        - properties
-      title: ComponentHLS
-      type: object
-      x-struct: Elixir.JellyfishWeb.ApiSpec.Component.HLS
-    HlsSkip:
-      description: Is delta manifest requested
-      enum:
-        - YES
-      example: YES
-      nullable: true
-      title: HlsSkip
-      type: string
-      x-struct: Elixir.JellyfishWeb.ApiSpec.HLS.Params.HlsSkip
-    ComponentFile:
-      description: Describes the File component
-      properties:
-        id:
-          description: Assigned component ID
-          example: component-1
-          type: string
-        type:
-          description: Component type
-          example: file
-          type: string
-      required:
-        - id
-        - type
-      title: ComponentFile
-      type: object
-      x-struct: Elixir.JellyfishWeb.ApiSpec.Component.File
-    SubscriptionConfig:
-      description: Subscription config
-      properties:
-        tracks:
-          description: List of tracks that hls endpoint will subscribe for
-          items:
-            $ref: '#/components/schemas/Track'
-          type: array
-      title: SubscriptionConfig
-      type: object
-      x-struct: Elixir.JellyfishWeb.ApiSpec.Subscription.Tracks
-    HlsMsn:
-      description: Segment sequence number
-      example: 10
-      minimum: 0
-      nullable: true
-      title: HlsMsn
-      type: integer
-      x-struct: Elixir.JellyfishWeb.ApiSpec.HLS.Params.HlsMsn
-    ComponentRTSP:
-      description: Describes the RTSP component
-      properties:
-        id:
-          description: Assigned component ID
-          example: component-1
-          type: string
-        properties:
-          $ref: '#/components/schemas/ComponentPropertiesRTSP'
-        type:
-          description: Component type
-          example: hls
-          type: string
-      required:
-        - id
-        - type
-        - properties
-      title: ComponentRTSP
-      type: object
-      x-struct: Elixir.JellyfishWeb.ApiSpec.Component.RTSP
-    HlsPart:
-      description: Partial segment sequence number
-      example: 10
-      minimum: 0
-      nullable: true
-      title: HlsPart
-      type: integer
-      x-struct: Elixir.JellyfishWeb.ApiSpec.HLS.Params.HlsPart
-    ComponentDetailsResponse:
-      description: Response containing component details
-      properties:
-        data:
-          $ref: '#/components/schemas/Component'
-      required:
-        - data
-      title: ComponentDetailsResponse
-      type: object
-      x-struct: Elixir.JellyfishWeb.ApiSpec.ComponentDetailsResponse
-    ComponentOptionsHLS:
-      description: Options specific to the HLS component
-      properties:
-        lowLatency:
-          default: false
-          description: Whether the component should use LL-HLS
-          type: boolean
-        persistent:
-          default: false
-          description: Whether the video is stored after end of stream
-          type: boolean
-        s3:
-          description: Credentials to AWS S3 bucket.
-          nullable: true
-          oneOf:
-            - $ref: '#/components/schemas/S3Credentials'
-          type: object
-        subscribeMode:
-          default: auto
-          description: Whether the HLS component should subscribe to tracks automatically or manually.
-          enum:
-            - auto
-            - manual
-          type: string
-        targetWindowDuration:
-          description: Duration of stream available for viewer
-          nullable: true
-          type: integer
-      title: ComponentOptionsHLS
-      type: object
-      x-struct: Elixir.JellyfishWeb.ApiSpec.Component.HLS.Options
-    S3Credentials:
-      description: An AWS S3 credential that will be used to send HLS stream. The stream will only be uploaded if credentials are provided
-      properties:
-        accessKeyId:
-          description: An AWS access key identifier, linked to your AWS account.
-          type: string
-        bucket:
-          description: The name of the S3 bucket where your data will be stored.
-          type: string
-        region:
-          description: The AWS region where your bucket is located.
-          type: string
-        secretAccessKey:
-          description: The secret key that is linked to the Access Key ID.
-          type: string
-      required:
-        - accessKeyId
-        - secretAccessKey
-        - region
-        - bucket
-      title: S3Credentials
-      type: object
-      x-struct: Elixir.JellyfishWeb.ApiSpec.Component.HLS.S3
-    RecordingListResponse:
-      description: Response containing list of all recording
-      properties:
-        data:
-          items:
-            type: string
-          type: array
-      required:
-        - data
-      title: RecordingListResponse
-      type: object
-      x-struct: Elixir.JellyfishWeb.ApiSpec.RecordingListResponse
-    ComponentOptions:
-      description: Component-specific options
-      oneOf:
-        - $ref: '#/components/schemas/ComponentOptionsHLS'
-        - $ref: '#/components/schemas/ComponentOptionsRTSP'
-        - $ref: '#/components/schemas/ComponentOptionsFile'
-      title: ComponentOptions
-      type: object
-      x-struct: Elixir.JellyfishWeb.ApiSpec.Component.Options
-    Track:
-      description: Track id
-      example: track-1
-      title: Track
-      type: string
-      x-struct: Elixir.JellyfishWeb.ApiSpec.Subscription.Track
-    ComponentPropertiesRTSP:
-      description: Properties specific to the RTSP component
-      properties: {}
-      title: ComponentPropertiesRTSP
-      type: object
-      x-struct: Elixir.JellyfishWeb.ApiSpec.Component.RTSP.Properties
-    PeerOptions:
-      description: Peer-specific options
-      oneOf:
-        - $ref: '#/components/schemas/PeerOptionsWebRTC'
-      title: PeerOptions
-      type: object
-      x-struct: Elixir.JellyfishWeb.ApiSpec.Peer.Options
-    Peer:
-      description: Describes peer status
-      properties:
-        id:
-          description: Assigned peer id
-          example: peer-1
-          type: string
-        status:
-          $ref: '#/components/schemas/PeerStatus'
-        type:
-          $ref: '#/components/schemas/PeerType'
-      required:
-        - id
-        - type
-        - status
-      title: Peer
-      type: object
-      x-struct: Elixir.JellyfishWeb.ApiSpec.Peer
-    ComponentType:
-      description: Component type
-      example: hls
-      title: ComponentType
-      type: string
-      x-struct: Elixir.JellyfishWeb.ApiSpec.Component.Type
-    AuthToken:
-      description: Token for authorizing websocket connection
-      example: 5cdac726-57a3-4ecb-b1d5-72a3d62ec242
-      title: AuthToken
-      type: string
-      x-struct: Elixir.JellyfishWeb.ApiSpec.Peer.Token
-    RoomsListingResponse:
-      description: Response containing list of all rooms
-      properties:
-        data:
-          items:
-            $ref: '#/components/schemas/Room'
-          type: array
-      required:
-        - data
-      title: RoomsListingResponse
-      type: object
-      x-struct: Elixir.JellyfishWeb.ApiSpec.RoomsListingResponse
-    PeerDetailsResponse:
-      description: Response containing peer details and their token
-      properties:
-        data:
-          properties:
-            peer:
-              $ref: '#/components/schemas/Peer'
-            token:
-              $ref: '#/components/schemas/AuthToken'
-          required:
-            - peer
-            - token
-          type: object
-      required:
-        - data
-      title: PeerDetailsResponse
-      type: object
-      x-struct: Elixir.JellyfishWeb.ApiSpec.PeerDetailsResponse
-    HlsResponse:
-      description: Requested file
-      title: HlsResponse
-      type: string
-      x-struct: Elixir.JellyfishWeb.ApiSpec.HLS.Response
-    PeerType:
-      description: Peer type
-      example: webrtc
-      title: PeerType
-      type: string
-      x-struct: Elixir.JellyfishWeb.ApiSpec.Peer.Type
-    RoomCreateDetailsResponse:
-      description: Response containing room details
-      properties:
-        data:
-          properties:
-            jellyfish_address:
-              description: Jellyfish instance address where the room was created. This might be different than the address of Jellyfish where the request was sent only when running a cluster of Jellyfishes.
-              example: jellyfish1:5003
-              type: string
-            room:
-              $ref: '#/components/schemas/Room'
-          required:
-            - room
-            - jellyfish_address
-          type: object
-      required:
-        - data
-      title: RoomCreateDetailsResponse
-      type: object
-      x-struct: Elixir.JellyfishWeb.ApiSpec.RoomCreateDetailsResponse
-    ComponentOptionsFile:
-      description: Options specific to the File component
-      properties:
-        filePath:
-          description: Path to track file. Must be either OPUS encapsulated in Ogg or raw h264
-          example: /root/video.h264
-          type: string
-      required:
-        - filePath
-      title: ComponentOptionsFile
-      type: object
-      x-struct: Elixir.JellyfishWeb.ApiSpec.Component.File.Options
-    Error:
-      description: Error message
-      properties:
-        errors:
-          description: Error details
-          example: Token has expired
-          type: string
-      required:
-        - errors
-      title: Error
-      type: object
-      x-struct: Elixir.JellyfishWeb.ApiSpec.Error
     RoomConfig:
       description: Room configuration
       properties:
@@ -473,6 +370,71 @@ components:
       title: RoomConfig
       type: object
       x-struct: Elixir.JellyfishWeb.ApiSpec.Room.Config
+    RoomCreateDetailsResponse:
+      description: Response containing room details
+      properties:
+        data:
+          properties:
+            jellyfish_address:
+              description: Jellyfish instance address where the room was created. This might be different than the address of Jellyfish where the request was sent only when running a cluster of Jellyfishes.
+              example: jellyfish1:5003
+              type: string
+            room:
+              $ref: '#/components/schemas/Room'
+          required:
+            - room
+            - jellyfish_address
+          type: object
+      required:
+        - data
+      title: RoomCreateDetailsResponse
+      type: object
+      x-struct: Elixir.JellyfishWeb.ApiSpec.RoomCreateDetailsResponse
+    RoomDetailsResponse:
+      description: Response containing room details
+      properties:
+        data:
+          $ref: '#/components/schemas/Room'
+      required:
+        - data
+      title: RoomDetailsResponse
+      type: object
+      x-struct: Elixir.JellyfishWeb.ApiSpec.RoomDetailsResponse
+    RoomsListingResponse:
+      description: Response containing list of all rooms
+      properties:
+        data:
+          items:
+            $ref: '#/components/schemas/Room'
+          type: array
+      required:
+        - data
+      title: RoomsListingResponse
+      type: object
+      x-struct: Elixir.JellyfishWeb.ApiSpec.RoomsListingResponse
+    S3Credentials:
+      description: An AWS S3 credential that will be used to send HLS stream. The stream will only be uploaded if credentials are provided
+      properties:
+        accessKeyId:
+          description: An AWS access key identifier, linked to your AWS account.
+          type: string
+        bucket:
+          description: The name of the S3 bucket where your data will be stored.
+          type: string
+        region:
+          description: The AWS region where your bucket is located.
+          type: string
+        secretAccessKey:
+          description: The secret key that is linked to the Access Key ID.
+          type: string
+      required:
+        - accessKeyId
+        - secretAccessKey
+        - region
+        - bucket
+      title: S3Credentials
+      type: object
+      x-struct: Elixir.JellyfishWeb.ApiSpec.Component.HLS.S3
   securitySchemes:
     authorization:
       scheme: bearer
@@ -488,7 +450,7 @@ paths:
   /hls/{room_id}/subscribe:
     post:
       callbacks: {}
-      operationId: subscribe_tracks
+      operationId: subscribe_peers
       parameters:
         - description: Room ID
           in: path
@@ -500,12 +462,12 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/SubscriptionConfig'
+              $ref: '#/components/schemas/Peer'
         description: Subscribe configuration
         required: false
       responses:
         '201':
-          description: Tracks succesfully added.
+          description: Peers succesfully added.
         '400':
           content:
             application/json:
@@ -518,7 +480,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: Room doesn't exist
-      summary: Subscribe hls component for tracks
+      summary: Subscribe hls component for peers
       tags:
         - hls
   /hls/{room_id}/{filename}:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -262,12 +262,6 @@ components:
       title: HlsSkip
       type: string
       x-struct: Elixir.JellyfishWeb.ApiSpec.HLS.Params.HlsSkip
-    Origin:
-      description: Component or Peer id
-      example: peer-id
-      title: Origin
-      type: string
-      x-struct: Elixir.JellyfishWeb.ApiSpec.Subscription.Origin
     Peer:
       description: Describes peer status
       properties:
@@ -462,6 +456,17 @@ components:
       title: S3Credentials
       type: object
       x-struct: Elixir.JellyfishWeb.ApiSpec.Component.HLS.S3
+    SubscriptionConfig:
+      description: Subscription config
+      properties:
+        origins:
+          description: List of peers and components whose tracks the HLS endpoint will subscribe to
+          items:
+            type: string
+          type: array
+      title: SubscriptionConfig
+      type: object
+      x-struct: Elixir.JellyfishWeb.ApiSpec.Subscription.Origins
   securitySchemes:
     authorization:
       scheme: bearer
@@ -489,7 +494,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Origin'
+              $ref: '#/components/schemas/SubscriptionConfig'
         description: Subscribe configuration
         required: false
       responses:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -460,7 +460,7 @@ components:
       description: Subscription config
       properties:
         origins:
-          description: List of peers and components whose tracks the HLS endpoint will subscribe to
+          description: List of peers and components ids whose tracks the HLS endpoint will subscribe to
           items:
             type: string
           type: array

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -262,12 +262,30 @@ components:
       title: HlsSkip
       type: string
       x-struct: Elixir.JellyfishWeb.ApiSpec.HLS.Params.HlsSkip
-    Peer:
-      description: Peer id
+    Origin:
+      description: Component or Peer id
       example: peer-id
-      title: Peer
+      title: Origin
       type: string
-      x-struct: Elixir.JellyfishWeb.ApiSpec.Subscription.Peer
+      x-struct: Elixir.JellyfishWeb.ApiSpec.Subscription.Origin
+    Peer:
+      description: Describes peer status
+      properties:
+        id:
+          description: Assigned peer id
+          example: peer-1
+          type: string
+        status:
+          $ref: '#/components/schemas/PeerStatus'
+        type:
+          $ref: '#/components/schemas/PeerType'
+      required:
+        - id
+        - type
+        - status
+      title: Peer
+      type: object
+      x-struct: Elixir.JellyfishWeb.ApiSpec.Peer
     PeerDetailsResponse:
       description: Response containing peer details and their token
       properties:
@@ -303,6 +321,15 @@ components:
       title: PeerOptionsWebRTC
       type: object
       x-struct: Elixir.JellyfishWeb.ApiSpec.Peer.WebRTC
+    PeerStatus:
+      description: Informs about the peer status
+      enum:
+        - connected
+        - disconnected
+      example: disconnected
+      title: PeerStatus
+      type: string
+      x-struct: Elixir.JellyfishWeb.ApiSpec.Peer.Status
     PeerType:
       description: Peer type
       example: webrtc
@@ -450,7 +477,7 @@ paths:
   /hls/{room_id}/subscribe:
     post:
       callbacks: {}
-      operationId: subscribe_peers
+      operationId: subscribe_hls_to
       parameters:
         - description: Room ID
           in: path
@@ -462,12 +489,12 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Peer'
+              $ref: '#/components/schemas/Origin'
         description: Subscribe configuration
         required: false
       responses:
         '201':
-          description: Peers succesfully added.
+          description: Tracks succesfully added.
         '400':
           content:
             application/json:
@@ -480,7 +507,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: Room doesn't exist
-      summary: Subscribe hls component for peers
+      summary: Subscribe the HLS component to the tracks of peers or components
       tags:
         - hls
   /hls/{room_id}/{filename}:

--- a/test/jellyfish_web/controllers/subscription_controller_test.exs
+++ b/test/jellyfish_web/controllers/subscription_controller_test.exs
@@ -24,7 +24,7 @@ defmodule JellyfishWeb.SubscriptionControllerTest do
     end
 
     test "returns error when hls component doesn't exist", %{conn: conn, room_id: room_id} do
-      conn = post(conn, ~p"/hls/#{room_id}/subscribe/", peers: ["peer-1", "file-2"])
+      conn = post(conn, ~p"/hls/#{room_id}/subscribe/", origins: ["peer-1", "file-2"])
       assert json_response(conn, :bad_request)["errors"] == "HLS component does not exist"
     end
 
@@ -43,7 +43,7 @@ defmodule JellyfishWeb.SubscriptionControllerTest do
              } =
                json_response(conn, :created)
 
-      conn = post(conn, ~p"/hls/#{room_id}/subscribe/", peers: ["peer-1", "rtsp-2"])
+      conn = post(conn, ~p"/hls/#{room_id}/subscribe/", origins: ["peer-1", "rtsp-2"])
 
       assert json_response(conn, :bad_request)["errors"] ==
                "HLS component option `subscribe_mode` is set to :auto"
@@ -64,7 +64,7 @@ defmodule JellyfishWeb.SubscriptionControllerTest do
              } =
                json_response(conn, :created)
 
-      conn = post(conn, ~p"/hls/#{room_id}/subscribe/", peers: ["peer-1", "file-2"])
+      conn = post(conn, ~p"/hls/#{room_id}/subscribe/", origins: ["peer-1", "file-2"])
 
       assert response(conn, :created) == "Successfully subscribed for tracks"
     end

--- a/test/jellyfish_web/controllers/subscription_controller_test.exs
+++ b/test/jellyfish_web/controllers/subscription_controller_test.exs
@@ -19,12 +19,12 @@ defmodule JellyfishWeb.SubscriptionControllerTest do
 
   describe "subscription" do
     test "returns error when room doesn't exist", %{conn: conn} do
-      conn = post(conn, ~p"/hls/invalid_room_id/subscribe/", tracks: ["track-1", "track-2"])
+      conn = post(conn, ~p"/hls/invalid_room_id/subscribe/", origins: ["peer-1", "rtsp-2"])
       assert json_response(conn, :not_found)["errors"] == "Room invalid_room_id does not exist"
     end
 
     test "returns error when hls component doesn't exist", %{conn: conn, room_id: room_id} do
-      conn = post(conn, ~p"/hls/#{room_id}/subscribe/", tracks: ["track-1", "track-2"])
+      conn = post(conn, ~p"/hls/#{room_id}/subscribe/", peers: ["peer-1", "file-2"])
       assert json_response(conn, :bad_request)["errors"] == "HLS component does not exist"
     end
 
@@ -43,7 +43,7 @@ defmodule JellyfishWeb.SubscriptionControllerTest do
              } =
                json_response(conn, :created)
 
-      conn = post(conn, ~p"/hls/#{room_id}/subscribe/", tracks: ["track-1", "track-2"])
+      conn = post(conn, ~p"/hls/#{room_id}/subscribe/", peers: ["peer-1", "rtsp-2"])
 
       assert json_response(conn, :bad_request)["errors"] ==
                "HLS component option `subscribe_mode` is set to :auto"
@@ -64,7 +64,7 @@ defmodule JellyfishWeb.SubscriptionControllerTest do
              } =
                json_response(conn, :created)
 
-      conn = post(conn, ~p"/hls/#{room_id}/subscribe/", tracks: ["track-1", "track-2"])
+      conn = post(conn, ~p"/hls/#{room_id}/subscribe/", peers: ["peer-1", "file-2"])
 
       assert response(conn, :created) == "Successfully subscribed for tracks"
     end


### PR DESCRIPTION
## Acknowledging the stipulations set forth:
 - [ ] I hereby confirm that a Pull Request involving updates to the Software Development Kit (SDK) has been smoothly merged, currently awaits processing, or is otherwise deemed unnecessary in this context.
 - [ ] I also affirm that another Pull Request, specifically addressing updates to the documentation body (commonly referred to as 'docs'), has either been successfully incorporated, is in the process of review, or is considered superfluous under the prevailing circumstances.
