### PR TITLE
[RTC-454] Healthcheck endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -126,7 +126,7 @@ RUN chmod +x docker-entrypoint.sh
 
 ENV HOME=/app
 
-HEALTHCHECK CMD curl --fail -H "authorization: Bearer ${JF_SERVER_API_TOKEN}" http://localhost:${JF_PORT:-8080}/room || exit 1
+HEALTHCHECK CMD curl --fail -H "authorization: Bearer ${JF_SERVER_API_TOKEN}" http://localhost:${JF_PORT:-8080}/health || exit 1
 
 ENTRYPOINT ["./docker-entrypoint.sh"]
 

--- a/lib/jellyfish/application.ex
+++ b/lib/jellyfish/application.ex
@@ -48,6 +48,8 @@ defmodule Jellyfish.Application do
     # for other strategies and supported options
     opts = [strategy: :one_for_one, name: Jellyfish.Supervisor]
 
+    Application.put_env(:jellyfish, :start_time, System.monotonic_time(:second))
+
     Logger.info("Starting Jellyfish v#{@version}")
     Logger.info("Distribution config: #{inspect(Keyword.delete(dist_config, :cookie))}")
     Logger.info("WebRTC config: #{inspect(webrtc_config)}")

--- a/lib/jellyfish_web/api_spec/health_report.ex
+++ b/lib/jellyfish_web/api_spec/health_report.ex
@@ -1,0 +1,29 @@
+defmodule JellyfishWeb.ApiSpec.HealthReport do
+  @moduledoc false
+
+  require OpenApiSpex
+
+  defmodule Status do
+    @moduledoc false
+
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "HealthReportStatus",
+      description: "Informs about the status of Jellyfish",
+      type: :string,
+      enum: ["UP", "DOWN"],
+      example: "UP"
+    })
+  end
+
+  OpenApiSpex.schema(%{
+    title: "HealthReport",
+    description: "Describes overall Jellyfish health",
+    type: :object,
+    properties: %{
+      status: Status
+    },
+    required: [:status]
+  })
+end

--- a/lib/jellyfish_web/api_spec/health_report.ex
+++ b/lib/jellyfish_web/api_spec/health_report.ex
@@ -2,6 +2,7 @@ defmodule JellyfishWeb.ApiSpec.HealthReport do
   @moduledoc false
 
   require OpenApiSpex
+  alias OpenApiSpex.Schema
 
   defmodule Status do
     @moduledoc false
@@ -10,10 +11,35 @@ defmodule JellyfishWeb.ApiSpec.HealthReport do
 
     OpenApiSpex.schema(%{
       title: "HealthReportStatus",
-      description: "Informs about the status of Jellyfish",
+      description: "Informs about the status of Jellyfish or a specific service",
       type: :string,
       enum: ["UP", "DOWN"],
       example: "UP"
+    })
+  end
+
+  defmodule Distribution do
+    @moduledoc false
+
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "HealthReportDistribution",
+      description: "Informs about the status of Jellyfish distribution",
+      type: :object,
+      properties: %{
+        enabled: %Schema{
+          type: :boolean,
+          description: "Whether distribution is enabled on this Jellyfish"
+        },
+        nodeStatus: Status,
+        nodesInCluster: %Schema{
+          type: :integer,
+          description:
+            "Amount of nodes (including this Jellyfish's node) in the distribution cluster"
+        }
+      },
+      required: [:nodeStatus, :nodesInCluster]
     })
   end
 
@@ -22,8 +48,10 @@ defmodule JellyfishWeb.ApiSpec.HealthReport do
     description: "Describes overall Jellyfish health",
     type: :object,
     properties: %{
-      status: Status
+      status: Status,
+      uptime: %Schema{type: :integer, description: "Uptime of Jellyfish (in seconds)"},
+      distribution: Distribution
     },
-    required: [:status]
+    required: [:status, :uptime, :distribution]
   })
 end

--- a/lib/jellyfish_web/api_spec/responses.ex
+++ b/lib/jellyfish_web/api_spec/responses.ex
@@ -25,7 +25,9 @@
   {RoomsListingResponse, "Response containing list of all rooms",
    %OpenApiSpex.Schema{type: :array, items: JellyfishWeb.ApiSpec.Room}},
   {RecordingListResponse, "Response containing list of all recording",
-   %OpenApiSpex.Schema{type: :array, items: %OpenApiSpex.Schema{type: :string}}}
+   %OpenApiSpex.Schema{type: :array, items: %OpenApiSpex.Schema{type: :string}}},
+  {HealthcheckResponse, "Response containing health report of Jellyfish",
+   JellyfishWeb.ApiSpec.HealthReport}
 ]
 |> Enum.map(fn {title, description, schema} ->
   module = Module.concat(JellyfishWeb.ApiSpec, title)

--- a/lib/jellyfish_web/controllers/healthcheck_controller.ex
+++ b/lib/jellyfish_web/controllers/healthcheck_controller.ex
@@ -15,8 +15,33 @@ defmodule JellyfishWeb.HealthcheckController do
     ]
 
   def show(conn, _params) do
+    report = get_health_report()
+
     conn
     |> put_resp_content_type("application/json")
-    |> render("show.json", status: "UP")
+    |> render("show.json", report: report)
+  end
+
+  defp get_health_report() do
+    %{
+      status: :up,
+      uptime: get_uptime(),
+      distribution: get_distribution_report()
+    }
+  end
+
+  defp get_uptime() do
+    System.monotonic_time(:second) - Application.fetch_env!(:jellyfish, :start_time)
+  end
+
+  defp get_distribution_report() do
+    alive? = Node.alive?()
+    visible_nodes = Node.list() |> length()
+
+    %{
+      enabled: Application.fetch_env!(:jellyfish, :dist_config)[:enabled],
+      node_status: if(alive?, do: :up, else: :down),
+      nodes_in_cluster: visible_nodes + if(alive?, do: 1, else: 0)
+    }
   end
 end

--- a/lib/jellyfish_web/controllers/healthcheck_controller.ex
+++ b/lib/jellyfish_web/controllers/healthcheck_controller.ex
@@ -1,0 +1,22 @@
+defmodule JellyfishWeb.HealthcheckController do
+  use JellyfishWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+
+  alias JellyfishWeb.ApiSpec
+
+  action_fallback JellyfishWeb.FallbackController
+
+  operation :show,
+    operation_id: "healthcheck",
+    summary: "Describes the health of Jellyfish",
+    responses: [
+      ok: ApiSpec.data("Healthy", ApiSpec.HealthcheckResponse),
+      internal_server_error: ApiSpec.data("Unhealthy", ApiSpec.HealthcheckResponse)
+    ]
+
+  def show(conn, _params) do
+    conn
+    |> put_resp_content_type("application/json")
+    |> render("show.json", status: "UP")
+  end
+end

--- a/lib/jellyfish_web/controllers/healthcheck_json.ex
+++ b/lib/jellyfish_web/controllers/healthcheck_json.ex
@@ -1,0 +1,7 @@
+defmodule JellyfishWeb.HealthcheckJSON do
+  @moduledoc false
+
+  def show(%{status: status}) do
+    %{data: %{status: status}}
+  end
+end

--- a/lib/jellyfish_web/controllers/healthcheck_json.ex
+++ b/lib/jellyfish_web/controllers/healthcheck_json.ex
@@ -1,7 +1,22 @@
 defmodule JellyfishWeb.HealthcheckJSON do
   @moduledoc false
 
-  def show(%{status: status}) do
-    %{data: %{status: status}}
+  def show(%{report: report}) do
+    %{data: data(report)}
   end
+
+  def data(%{status: status, uptime: uptime, distribution: distribution}) do
+    %{
+      status: status_str(status),
+      uptime: uptime,
+      distribution: %{
+        enabled: distribution.enabled,
+        nodeStatus: status_str(distribution.node_status),
+        nodesInCluster: distribution.nodes_in_cluster
+      }
+    }
+  end
+
+  defp status_str(:up), do: "UP"
+  defp status_str(:down), do: "DOWN"
 end

--- a/lib/jellyfish_web/router.ex
+++ b/lib/jellyfish_web/router.ex
@@ -6,6 +6,12 @@ defmodule JellyfishWeb.Router do
     plug :bearer_auth
   end
 
+  scope "/health", JellyfishWeb do
+    pipe_through :api
+
+    get "/", HealthcheckController, :show
+  end
+
   scope "/room", JellyfishWeb do
     pipe_through :api
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -14,6 +14,15 @@ components:
       title: PeerStatus
       type: string
       x-struct: Elixir.JellyfishWeb.ApiSpec.Peer.Status
+    HealthReportStatus:
+      description: Informs about the status of Jellyfish
+      enum:
+        - UP
+        - DOWN
+      example: UP
+      title: HealthReportStatus
+      type: string
+      x-struct: Elixir.JellyfishWeb.ApiSpec.HealthReport.Status
     RoomDetailsResponse:
       description: Response containing room details
       properties:
@@ -139,6 +148,16 @@ components:
       title: PeerOptionsWebRTC
       type: object
       x-struct: Elixir.JellyfishWeb.ApiSpec.Peer.WebRTC
+    HealthcheckResponse:
+      description: Response containing health report of Jellyfish
+      properties:
+        data:
+          $ref: '#/components/schemas/HealthReport'
+      required:
+        - data
+      title: HealthcheckResponse
+      type: object
+      x-struct: Elixir.JellyfishWeb.ApiSpec.HealthcheckResponse
     ComponentHLS:
       description: Describes the HLS component
       properties:
@@ -362,6 +381,16 @@ components:
       title: PeerOptions
       type: object
       x-struct: Elixir.JellyfishWeb.ApiSpec.Peer.Options
+    HealthReport:
+      description: Describes overall Jellyfish health
+      properties:
+        status:
+          $ref: '#/components/schemas/HealthReportStatus'
+      required:
+        - status
+      title: HealthReport
+      type: object
+      x-struct: Elixir.JellyfishWeb.ApiSpec.HealthReport
     Peer:
       description: Describes peer status
       properties:
@@ -517,6 +546,26 @@ info:
   version: 0.2.0
 openapi: 3.0.0
 paths:
+  /health:
+    get:
+      callbacks: {}
+      operationId: healthcheck
+      parameters: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HealthcheckResponse'
+          description: Healthy
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HealthcheckResponse'
+          description: Unhealthy
+      summary: Describes the health of Jellyfish
+      tags: []
   /hls/{room_id}/subscribe:
     post:
       callbacks: {}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -15,7 +15,7 @@ components:
       type: string
       x-struct: Elixir.JellyfishWeb.ApiSpec.Peer.Status
     HealthReportStatus:
-      description: Informs about the status of Jellyfish
+      description: Informs about the status of Jellyfish or a specific service
       enum:
         - UP
         - DOWN
@@ -347,6 +347,23 @@ components:
       title: ComponentOptions
       type: object
       x-struct: Elixir.JellyfishWeb.ApiSpec.Component.Options
+    HealthReportDistribution:
+      description: Informs about the status of Jellyfish distribution
+      properties:
+        enabled:
+          description: Whether distribution is enabled on this Jellyfish
+          type: boolean
+        nodeStatus:
+          $ref: '#/components/schemas/HealthReportStatus'
+        nodesInCluster:
+          description: Amount of nodes (including this Jellyfish's node) in the distribution cluster
+          type: integer
+      required:
+        - nodeStatus
+        - nodesInCluster
+      title: HealthReportDistribution
+      type: object
+      x-struct: Elixir.JellyfishWeb.ApiSpec.HealthReport.Distribution
     ComponentPropertiesRTSP:
       description: Properties specific to the RTSP component
       properties:
@@ -384,10 +401,17 @@ components:
     HealthReport:
       description: Describes overall Jellyfish health
       properties:
+        distribution:
+          $ref: '#/components/schemas/HealthReportDistribution'
         status:
           $ref: '#/components/schemas/HealthReportStatus'
+        uptime:
+          description: Uptime of Jellyfish (in seconds)
+          type: integer
       required:
         - status
+        - uptime
+        - distribution
       title: HealthReport
       type: object
       x-struct: Elixir.JellyfishWeb.ApiSpec.HealthReport

--- a/test/jellyfish_web/controllers/healthcheck_controller_test.exs
+++ b/test/jellyfish_web/controllers/healthcheck_controller_test.exs
@@ -1,0 +1,30 @@
+defmodule JellyfishWeb.HealthcheckControllerTest do
+  use JellyfishWeb.ConnCase, async: true
+
+  import OpenApiSpex.TestAssertions
+
+  @schema JellyfishWeb.ApiSpec.spec()
+
+  setup %{conn: conn} do
+    server_api_token = Application.fetch_env!(:jellyfish, :server_api_token)
+    conn = put_req_header(conn, "authorization", "Bearer " <> server_api_token)
+
+    [conn: conn]
+  end
+
+  test "healthcheck without distribution", %{conn: conn} do
+    conn = get(conn, ~p"/health")
+    response = json_response(conn, :ok)
+    assert_response_schema(response, "HealthcheckResponse", @schema)
+
+    assert %{
+             "status" => "UP",
+             "uptime" => _uptime,
+             "distribution" => %{
+               "enabled" => false,
+               "nodeStatus" => "DOWN",
+               "nodesInCluster" => 0
+             }
+           } = response["data"]
+  end
+end


### PR DESCRIPTION
About the topic:
https://emmer.dev/blog/writing-meaningful-health-check-endpoints/
https://tyk.io/blog/api-health-checks-how-to-keep-apps-healthy/


There are several things we need to consider:

1. Whether we want to perform some actual checks before responding (+ include some additional data in the response)
    1. We're effectively returning a hard-coded 200 every time, which seems more like a ping endpoint than a healthcheck endpoint...
    2. ...but:
        1. We don't have any microservices or databases we depend on
        2. There is little need for the distinction between *live* and *ready* states of Jellyfish:
            1. When it starts, it should function correctly from the get-go
            2. During its lifetime, we could designate it as *not-ready* whenever the load is too high to handle more traffic, but detecting that from within the app wouldn't be trivial
        3. We already have metrics reporting resource usage, amount of rooms etc. We could consider adding uptime, I guess (?)
2. Whether issuing healthcheck requests should require authentication
    1. IMO right now it isn't necessary, but if we choose to include anything other than `{"status": "UP"}` in the response, we should use auth

Discussion on these topics is welcome 🙂 



## Acknowledging the stipulations set forth:
 - [x] I hereby confirm that a Pull Request involving updates to the Software Development Kit (SDK) has been smoothly merged, currently awaits processing, or is otherwise deemed unnecessary in this context.
 - [x] I also affirm that another Pull Request, specifically addressing updates to the documentation body (commonly referred to as 'docs'), has either been successfully incorporated, is in the process of review, or is considered superfluous under the prevailing circumstances.