### PR TITLE
Fix duplicated `peer_disconnected` notification

### DIFF
--- a/lib/jellyfish/room.ex
+++ b/lib/jellyfish/room.ex
@@ -231,7 +231,9 @@ defmodule Jellyfish.Room do
           do: send(peer.socket_pid, {:stop_connection, :peer_removed})
 
         Logger.info("Removed peer #{inspect(peer_id)} from room #{inspect(state.id)}")
-        Event.broadcast_server_notification({:peer_disconnected, state.id, peer_id})
+
+        if peer.status == :connected,
+          do: Event.broadcast_server_notification({:peer_disconnected, state.id, peer_id})
 
         {:ok, state}
       else


### PR DESCRIPTION
The current flow of peer disconnecting from JellyRoom: 
* peer disconnects, and closes socket -> we send `disconnected` notification
* backend reacts on the notification and removes peer -> we send another notification

## Acknowledging the stipulations set forth:
 - [ x ] I hereby confirm that a Pull Request involving updates to the Software Development Kit (SDK) has been smoothly merged, currently awaits processing, or is otherwise deemed unnecessary in this context.
 - [ x ] I also affirm that another Pull Request, specifically addressing updates to the documentation body (commonly referred to as 'docs'), has either been successfully incorporated, is in the process of review, or is considered superfluous under the prevailing circumstances.
