### PR TITLE
[RTC-471] Fix auth not required for /hls and /recording requests

### DIFF
--- a/lib/jellyfish_web/controllers/healthcheck_controller.ex
+++ b/lib/jellyfish_web/controllers/healthcheck_controller.ex
@@ -6,12 +6,14 @@ defmodule JellyfishWeb.HealthcheckController do
 
   action_fallback JellyfishWeb.FallbackController
 
+  tags [:health]
+
   operation :show,
     operation_id: "healthcheck",
     summary: "Describes the health of Jellyfish",
     responses: [
       ok: ApiSpec.data("Healthy", ApiSpec.HealthcheckResponse),
-      internal_server_error: ApiSpec.data("Unhealthy", ApiSpec.HealthcheckResponse)
+      unauthorized: ApiSpec.error("Unauthorized")
     ]
 
   def show(conn, _params) do

--- a/lib/jellyfish_web/controllers/recording_controller.ex
+++ b/lib/jellyfish_web/controllers/recording_controller.ex
@@ -35,7 +35,8 @@ defmodule JellyfishWeb.RecordingController do
     summary: "Lists all available recordings",
     responses: [
       ok: ApiSpec.data("Success", ApiSpec.RecordingListResponse),
-      not_found: ApiSpec.error("Unable to obtain recordings")
+      not_found: ApiSpec.error("Unable to obtain recordings"),
+      unauthorized: ApiSpec.error("Unauthorized")
     ]
 
   operation :delete,
@@ -45,7 +46,8 @@ defmodule JellyfishWeb.RecordingController do
     responses: [
       no_content: %OpenApiSpex.Response{description: "Successfully deleted recording"},
       not_found: ApiSpec.error("Recording doesn't exist"),
-      bad_request: ApiSpec.error("Invalid recording")
+      bad_request: ApiSpec.error("Invalid recording"),
+      unauthorized: ApiSpec.error("Unauthorized")
     ]
 
   def index(conn, %{"recording_id" => recording_id, "filename" => filename}) do

--- a/lib/jellyfish_web/controllers/subscription_controller.ex
+++ b/lib/jellyfish_web/controllers/subscription_controller.ex
@@ -19,7 +19,8 @@ defmodule JellyfishWeb.SubscriptionController do
     responses: [
       created: %Response{description: "Tracks succesfully added."},
       bad_request: ApiSpec.error("Invalid request structure"),
-      not_found: ApiSpec.error("Room doesn't exist")
+      not_found: ApiSpec.error("Room doesn't exist"),
+      unauthorized: ApiSpec.error("Unauthorized")
     ]
 
   def create(conn, %{"room_id" => room_id} = params) do

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -642,14 +642,15 @@ paths:
               schema:
                 $ref: '#/components/schemas/HealthcheckResponse'
           description: Healthy
-        '500':
+        '401':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HealthcheckResponse'
-          description: Unhealthy
+                $ref: '#/components/schemas/Error'
+          description: Unauthorized
       summary: Describes the health of Jellyfish
-      tags: []
+      tags:
+        - health
   /hls/{room_id}/subscribe:
     post:
       callbacks: {}
@@ -677,6 +678,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: Invalid request structure
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unauthorized
         '404':
           content:
             application/json:
@@ -761,6 +768,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/RecordingListResponse'
           description: Success
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unauthorized
         '404':
           content:
             application/json:
@@ -790,6 +803,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: Invalid recording
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unauthorized
         '404':
           content:
             application/json:

--- a/test/jellyfish_web/controllers/recording_controller_test.exs
+++ b/test/jellyfish_web/controllers/recording_controller_test.exs
@@ -71,11 +71,14 @@ defmodule JellyfishWeb.RecordingControllerTest do
   end
 
   test "list of recordings", %{conn: conn} do
+    conn = inject_auth_headers(conn)
     conn = get(conn, ~p"/recording")
     assert @recording_id in json_response(conn, :ok)["data"]
   end
 
   test "delete recording", %{conn: conn} do
+    conn = inject_auth_headers(conn)
+
     @for_deleting_id
     |> Recording.directory()
     |> prepare_files()
@@ -96,6 +99,8 @@ defmodule JellyfishWeb.RecordingControllerTest do
   end
 
   test "delete whole recording directory", %{conn: conn} do
+    conn = inject_auth_headers(conn)
+
     conn
     |> delete(~p"/recording/.")
     |> json_response(:bad_request)
@@ -103,6 +108,8 @@ defmodule JellyfishWeb.RecordingControllerTest do
   end
 
   test "delete using invalid filename", %{conn: conn} do
+    conn = inject_auth_headers(conn)
+
     conn
     |> delete(~p"/recording/#{@outside_file}")
     |> json_response(:bad_request)
@@ -117,5 +124,13 @@ defmodule JellyfishWeb.RecordingControllerTest do
 
     segment_path = Path.join(output_path, @segment_name)
     File.write!(segment_path, @segment_content)
+  end
+
+  defp inject_auth_headers(conn) do
+    server_api_token = Application.fetch_env!(:jellyfish, :server_api_token)
+
+    conn
+    |> put_req_header("authorization", "Bearer " <> server_api_token)
+    |> put_req_header("accept", "application/json")
   end
 end


### PR DESCRIPTION
## Acknowledging the stipulations set forth:
 - [x] I hereby confirm that a Pull Request involving updates to the Software Development Kit (SDK) has been smoothly merged, currently awaits processing, or is otherwise deemed unnecessary in this context.
 - [x] I also affirm that another Pull Request, specifically addressing updates to the documentation body (commonly referred to as 'docs'), has either been successfully incorporated, is in the process of review, or is considered superfluous under the prevailing circumstances.
