### PR TITLE
Return peer_websocket_url in PeerDetailsResponse

### DIFF
--- a/lib/jellyfish.ex
+++ b/lib/jellyfish.ex
@@ -10,4 +10,14 @@ defmodule Jellyfish do
   @version Mix.Project.config()[:version]
 
   def version(), do: @version
+
+  @spec address() :: binary()
+  def address() do
+    Application.fetch_env!(:jellyfish, :address)
+  end
+
+  @spec peer_websocket_address() :: binary()
+  def peer_websocket_address() do
+    Application.fetch_env!(:jellyfish, :address) <> "/socket/peer/websocket"
+  end
 end

--- a/lib/jellyfish/application.ex
+++ b/lib/jellyfish/application.ex
@@ -75,16 +75,6 @@ defmodule Jellyfish.Application do
     :ok
   end
 
-  @spec get_jellyfish_address() :: binary()
-  def get_jellyfish_address() do
-    Application.fetch_env!(:jellyfish, :address)
-  end
-
-  @spec get_peer_websocket_address() :: binary()
-  def get_peer_websocket_address() do
-    Application.fetch_env!(:jellyfish, :address) <> "/socket/peer/websocket"
-  end
-
   defp config_distribution(dist_config) do
     :ok = ensure_epmd_started!()
 

--- a/lib/jellyfish/application.ex
+++ b/lib/jellyfish/application.ex
@@ -75,6 +75,16 @@ defmodule Jellyfish.Application do
     :ok
   end
 
+  @spec get_jellyfish_address() :: binary()
+  def get_jellyfish_address() do
+    Application.fetch_env!(:jellyfish, :address)
+  end
+
+  @spec get_peer_websocket_address() :: binary()
+  def get_peer_websocket_address() do
+    Application.fetch_env!(:jellyfish, :address) <> "/socket/peer"
+  end
+
   defp config_distribution(dist_config) do
     :ok = ensure_epmd_started!()
 

--- a/lib/jellyfish/application.ex
+++ b/lib/jellyfish/application.ex
@@ -82,7 +82,7 @@ defmodule Jellyfish.Application do
 
   @spec get_peer_websocket_address() :: binary()
   def get_peer_websocket_address() do
-    Application.fetch_env!(:jellyfish, :address) <> "/socket/peer"
+    Application.fetch_env!(:jellyfish, :address) <> "/socket/peer/websocket"
   end
 
   defp config_distribution(dist_config) do

--- a/lib/jellyfish/resource_manager.ex
+++ b/lib/jellyfish/resource_manager.ex
@@ -26,6 +26,17 @@ defmodule Jellyfish.ResourceManager do
   def init(opts) do
     Logger.debug("Initialize resource manager")
 
+    base_path = Recording.get_base_path()
+    dir_result = File.mkdir_p(base_path)
+
+    case dir_result do
+      {:error, reason} ->
+        Logger.error("Can't create directory at #{base_path} with reason: #{reason}")
+
+      :ok ->
+        nil
+    end
+
     schedule_free_resources(opts.interval)
 
     {:ok, opts}

--- a/lib/jellyfish/room_service.ex
+++ b/lib/jellyfish/room_service.ex
@@ -146,7 +146,7 @@ defmodule Jellyfish.RoomService do
 
       Event.broadcast_server_notification({:room_created, room_id})
 
-      {:reply, {:ok, room, Application.fetch_env!(:jellyfish, :address)}, state}
+      {:reply, {:ok, room, Jellyfish.Application.get_jellyfish_address()}, state}
     else
       {:error, :room_already_exists} = error ->
         {:reply, error, state}

--- a/lib/jellyfish/room_service.ex
+++ b/lib/jellyfish/room_service.ex
@@ -146,7 +146,7 @@ defmodule Jellyfish.RoomService do
 
       Event.broadcast_server_notification({:room_created, room_id})
 
-      {:reply, {:ok, room, Jellyfish.Application.get_jellyfish_address()}, state}
+      {:reply, {:ok, room, Jellyfish.address()}, state}
     else
       {:error, :room_already_exists} = error ->
         {:reply, error, state}

--- a/lib/jellyfish_web/api_spec/peer.ex
+++ b/lib/jellyfish_web/api_spec/peer.ex
@@ -61,6 +61,19 @@ defmodule JellyfishWeb.ApiSpec.Peer do
     })
   end
 
+  defmodule WebSocketUrl do
+    @moduledoc false
+
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "WebsocketURL",
+      description: "Websocket URL to which peer has to connect",
+      type: :string,
+      example: "www.jellyfish.org/socket/peer"
+    })
+  end
+
   defmodule PeerMetadata do
     @moduledoc false
 

--- a/lib/jellyfish_web/api_spec/responses.ex
+++ b/lib/jellyfish_web/api_spec/responses.ex
@@ -2,7 +2,11 @@
   {PeerDetailsResponse, "Response containing peer details and their token",
    %OpenApiSpex.Schema{
      type: :object,
-     properties: %{peer: JellyfishWeb.ApiSpec.Peer, token: JellyfishWeb.ApiSpec.Peer.Token},
+     properties: %{
+       peer: JellyfishWeb.ApiSpec.Peer,
+       token: JellyfishWeb.ApiSpec.Peer.Token,
+       peer_websocket_url: JellyfishWeb.ApiSpec.Peer.WebSocketUrl
+     },
      required: [:peer, :token]
    }},
   {RoomDetailsResponse, "Response containing room details", JellyfishWeb.ApiSpec.Room},

--- a/lib/jellyfish_web/controllers/peer_controller.ex
+++ b/lib/jellyfish_web/controllers/peer_controller.ex
@@ -77,7 +77,7 @@ defmodule JellyfishWeb.PeerController do
       assigns = [
         peer: peer,
         token: PeerToken.generate(%{peer_id: peer.id, room_id: room_id}),
-        peer_websocket_url: Jellyfish.Application.get_peer_websocket_address()
+        peer_websocket_url: Jellyfish.peer_websocket_address()
       ]
 
       conn

--- a/lib/jellyfish_web/controllers/peer_controller.ex
+++ b/lib/jellyfish_web/controllers/peer_controller.ex
@@ -74,7 +74,11 @@ defmodule JellyfishWeb.PeerController do
          {:ok, peer_type} <- Peer.parse_type(peer_type_string),
          {:ok, _room_pid} <- RoomService.find_room(room_id),
          {:ok, peer} <- Room.add_peer(room_id, peer_type, peer_options) do
-      assigns = [peer: peer, token: PeerToken.generate(%{peer_id: peer.id, room_id: room_id})]
+      assigns = [
+        peer: peer,
+        token: PeerToken.generate(%{peer_id: peer.id, room_id: room_id}),
+        peer_websocket_url: Jellyfish.Application.get_peer_websocket_address()
+      ]
 
       conn
       |> put_resp_content_type("application/json")

--- a/lib/jellyfish_web/controllers/peer_json.ex
+++ b/lib/jellyfish_web/controllers/peer_json.ex
@@ -2,8 +2,8 @@ defmodule JellyfishWeb.PeerJSON do
   @moduledoc false
   alias Jellyfish.Peer.WebRTC
 
-  def show(%{peer: peer, token: token}) do
-    %{data: %{peer: data(peer), token: token}}
+  def show(%{peer: peer, token: token, peer_websocket_url: ws_url}) do
+    %{data: %{peer: data(peer), token: token, peer_websocket_url: ws_url}}
   end
 
   def show(%{peer: peer}) do

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -397,6 +397,12 @@ components:
       title: HlsPart
       type: integer
       x-struct: Elixir.JellyfishWeb.ApiSpec.HLS.Params.HlsPart
+    WebsocketURL:
+      description: Websocket URL to which peer has to connect
+      example: www.jellyfish.org/socket/peer
+      title: WebsocketURL
+      type: string
+      x-struct: Elixir.JellyfishWeb.ApiSpec.Peer.WebSocketUrl
     ComponentDetailsResponse:
       description: Response containing component details
       properties:
@@ -681,6 +687,8 @@ components:
           properties:
             peer:
               $ref: '#/components/schemas/Peer'
+            peer_websocket_url:
+              $ref: '#/components/schemas/WebsocketURL'
             token:
               $ref: '#/components/schemas/AuthToken'
           required:

--- a/test/jellyfish_web/controllers/peer_controller_test.exs
+++ b/test/jellyfish_web/controllers/peer_controller_test.exs
@@ -22,7 +22,7 @@ defmodule JellyfishWeb.PeerControllerTest do
       assert response(conn, :no_content)
     end)
 
-    peer_ws_url = Jellyfish.Application.get_peer_websocket_address()
+    peer_ws_url = Jellyfish.peer_websocket_address()
 
     {:ok, %{conn: conn, room_id: id, peer_ws_url: peer_ws_url}}
   end

--- a/test/jellyfish_web/controllers/peer_controller_test.exs
+++ b/test/jellyfish_web/controllers/peer_controller_test.exs
@@ -22,17 +22,26 @@ defmodule JellyfishWeb.PeerControllerTest do
       assert response(conn, :no_content)
     end)
 
-    {:ok, %{conn: conn, room_id: id}}
+    peer_ws_url = Jellyfish.Application.get_peer_websocket_address()
+
+    {:ok, %{conn: conn, room_id: id, peer_ws_url: peer_ws_url}}
   end
 
   describe "create peer" do
-    test "renders peer when data is valid", %{conn: conn, room_id: room_id} do
+    test "renders peer when data is valid", %{
+      conn: conn,
+      room_id: room_id,
+      peer_ws_url: peer_ws_url
+    } do
       conn = post(conn, ~p"/room/#{room_id}/peer", type: @peer_type)
       response = json_response(conn, :created)
       assert_response_schema(response, "PeerDetailsResponse", @schema)
 
-      assert %{"peer" => %{"id" => peer_id, "type" => @peer_type}, "token" => token} =
-               response["data"]
+      assert %{
+               "peer" => %{"id" => peer_id, "type" => @peer_type},
+               "token" => token,
+               "peer_websocket_url" => ^peer_ws_url
+             } = response["data"]
 
       conn = get(conn, ~p"/room/#{room_id}")
 


### PR DESCRIPTION
This PR introduces two changes:
- Add peer websocket URL in PeerDetailsResponse
- ResourceManager adds `raw_recordings` directory if it doesn't exist. 

## Acknowledging the stipulations set forth:
 - [x] I hereby confirm that a Pull Request involving updates to the Software Development Kit (SDK) has been smoothly merged, currently awaits processing, or is otherwise deemed unnecessary in this context.
 - [x] I also affirm that another Pull Request, specifically addressing updates to the documentation body (commonly referred to as 'docs'), has either been successfully incorporated, is in the process of review, or is considered superfluous under the prevailing circumstances.

[Docs PR](https://github.com/jellyfish-dev/jellyfish-docs/pull/105)
[Elixir SDK PR](https://github.com/jellyfish-dev/elixir_server_sdk/pull/63)
[Python SDK PR](https://github.com/jellyfish-dev/python-server-sdk/pull/36)