### PR TITLE
use `getaddr` instead of `parse_address` to allow for hostnames

### DIFF
--- a/lib/jellyfish/config_reader.ex
+++ b/lib/jellyfish/config_reader.ex
@@ -24,7 +24,7 @@ defmodule Jellyfish.ConfigReader do
     if value = System.get_env(env) do
       value = value |> to_charlist()
 
-      case :inet.parse_address(value) do
+      case :inet.getaddr(value, :inet) do
         {:ok, parsed_ip} ->
           parsed_ip
 


### PR DESCRIPTION
## Acknowledging the stipulations set forth:
 - [x] I hereby confirm that a Pull Request involving updates to the Software Development Kit (SDK) has been smoothly merged, currently awaits processing, or is otherwise deemed unnecessary in this context.
 - [x] I also affirm that another Pull Request, specifically addressing updates to the documentation body (commonly referred to as 'docs'), has either been successfully incorporated, is in the process of review, or is considered superfluous under the prevailing circumstances.


I was looking to try a deploy on fly which requires setting:

```elixir
JF_WEBRTC_TURN_LISTEN_IP = "fly-global-services"
```

The problem is that `config_reader` runs `JF_WEBRTC_TURN_LISTEN_IP` through `:inet.parse_address` and `fly-global-services` is not an ip, just a hostname.

```elixir
** (RuntimeError) Bad JF_WEBRTC_TURN_LISTEN_IP environment variable value. Expected valid ip address, got: fly-global-services"
(jellyfish 0.4.1) lib/jellyfish/config_reader.ex:32: Jellyfish.ConfigReader.read_ip/1
```

One interesting note is that if I ignore the parsing altogether, without using `parse_address` or `getaddr` it then fails at the `membrane_ice_plugin` level. I don't have the logs for that anymore, but the plugin raises with some `badarg` value when passing in a hostname as the turn_ip.

With this change, we convert the hostname to it's underlying ip and `jellyfish` and `membrane_ice_plugin` works again. My understanding is that `getaddr` works equally with `ip`s and `hostnames` but more testing could be done.