### PR TITLE
[RTC-526] Add env vars to configure allowed components

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -34,8 +34,8 @@ config :jellyfish,
   metrics_port: ConfigReader.read_port("JF_METRICS_PORT") || 9568,
   dist_config: ConfigReader.read_dist_config(),
   webrtc_config: ConfigReader.read_webrtc_config(),
+  component_used?: ConfigReader.read_components_used(),
   sip_config: ConfigReader.read_sip_config(),
-  recording_config: ConfigReader.read_recording_config(),
   s3_config: ConfigReader.read_s3_config(),
   git_commit: ConfigReader.read_git_commit()
 

--- a/lib/jellyfish/component.ex
+++ b/lib/jellyfish/component.ex
@@ -123,7 +123,8 @@ defmodule Jellyfish.Component do
 
   @spec new(component(), map()) :: {:ok, t()} | {:error, term()}
   def new(type, options) do
-    with {:ok, %{endpoint: endpoint, properties: properties}} <-
+    with true <- component_allowed?(type),
+         {:ok, %{endpoint: endpoint, properties: properties}} <-
            type.config(options) do
       {:ok,
        %__MODULE__{
@@ -133,7 +134,17 @@ defmodule Jellyfish.Component do
          properties: properties
        }}
     else
-      {:error, _reason} = error -> error
+      false ->
+        raise("""
+          #{inspect(type)} can only be used if JF_#{type |> to_string!() |> String.upcase()}_USED environmental variable is set to \"true\"
+        """)
+
+      {:error, _reason} = error ->
+        error
     end
+  end
+
+  defp component_allowed?(type) do
+    Application.fetch_env!(:jellyfish, :component_used?)[:"#{to_string!(type)}"]
   end
 end

--- a/lib/jellyfish/component/recording.ex
+++ b/lib/jellyfish/component/recording.ex
@@ -13,14 +13,7 @@ defmodule Jellyfish.Component.Recording do
 
   @impl true
   def config(%{engine_pid: engine} = options) do
-    recording_config = Application.fetch_env!(:jellyfish, :recording_config)
     sink_config = Application.fetch_env!(:jellyfish, :s3_config)
-
-    unless recording_config[:recording_used?],
-      do:
-        raise("""
-        Recording components can only be used if JF_RECORDING_USED environmental variable is set to \"true\"
-        """)
 
     with {:ok, serialized_opts} <- serialize_options(options, Options.schema()),
          result_opts <- parse_subscribe_mode(serialized_opts),

--- a/lib/jellyfish/component/sip.ex
+++ b/lib/jellyfish/component/sip.ex
@@ -21,16 +21,7 @@ defmodule Jellyfish.Component.SIP do
 
   @impl true
   def config(%{engine_pid: engine} = options) do
-    sip_config = Application.fetch_env!(:jellyfish, :sip_config)
-
-    external_ip =
-      if sip_config[:sip_used?] do
-        Application.fetch_env!(:jellyfish, :sip_config)[:sip_external_ip]
-      else
-        raise """
-        SIP components can only be used if JF_SIP_USED environmental variable is set to \"true\"
-        """
-      end
+    external_ip = Application.fetch_env!(:jellyfish, :sip_config)[:sip_external_ip]
 
     with {:ok, serialized_opts} <- serialize_options(options, Options.schema()) do
       endpoint_spec = %SIP{

--- a/lib/jellyfish/config_reader.ex
+++ b/lib/jellyfish/config_reader.ex
@@ -128,6 +128,16 @@ defmodule Jellyfish.ConfigReader do
     end
   end
 
+  def read_components_used() do
+    [
+      hls: read_boolean("JF_HLS_USED") == true,
+      rtsp: read_boolean("JF_RTSP_USED") == true,
+      file: read_boolean("JF_FILE_USED") == true,
+      sip: read_boolean("JF_SIP_USED") == true,
+      recording: read_boolean("JF_RECORDING_USED") == true
+    ]
+  end
+
   def read_sip_config() do
     sip_used? = read_boolean("JF_SIP_USED")
     sip_ip = System.get_env("JF_SIP_IP") || ""
@@ -135,13 +145,11 @@ defmodule Jellyfish.ConfigReader do
     cond do
       sip_used? != true ->
         [
-          sip_used?: false,
           sip_external_ip: nil
         ]
 
       ip_address?(sip_ip) ->
         [
-          sip_used?: true,
           sip_external_ip: sip_ip
         ]
 
@@ -150,12 +158,6 @@ defmodule Jellyfish.ConfigReader do
         JF_SIP_USED has been set to true but incorrect IP address was provided as `JF_SIP_IP`
         """
     end
-  end
-
-  def read_recording_config() do
-    [
-      recording_used?: read_boolean("JF_RECORDING_USED") != false
-    ]
   end
 
   def read_s3_config() do

--- a/test/jellyfish/component_test.exs
+++ b/test/jellyfish/component_test.exs
@@ -1,0 +1,18 @@
+defmodule Jellyfish.ComponentTest do
+  use ExUnit.Case, async: true
+
+  alias Jellyfish.Component
+
+  test "component gets created only when allowed" do
+    options = %{
+      sourceUri: "rtsp://abcdefghijkl-12345678.org:23456/aaa/bbb/ccc",
+      engine_pid: self()
+    }
+
+    Application.put_env(:jellyfish, :component_used?, rtsp: true)
+    {:ok, _component} = Component.new(Component.RTSP, options)
+
+    Application.put_env(:jellyfish, :component_used?, rtsp: false)
+    assert_raise RuntimeError, fn -> Component.new(Component.RTSP, options) end
+  end
+end

--- a/test/jellyfish_web/controllers/component/file_component_test.exs
+++ b/test/jellyfish_web/controllers/component/file_component_test.exs
@@ -21,6 +21,8 @@ defmodule JellyfishWeb.Component.FileComponentTest do
   @auth_response %Authenticated{}
 
   setup_all _tags do
+    Application.put_env(:jellyfish, :component_used?, file: true)
+
     media_sources_directory =
       Application.fetch_env!(:jellyfish, :media_files_path)
       |> Path.join(@file_component_directory)
@@ -30,7 +32,10 @@ defmodule JellyfishWeb.Component.FileComponentTest do
 
     File.cp_r!(@fixtures_directory, media_sources_directory)
 
-    on_exit(fn -> :file.del_dir_r(media_sources_directory) end)
+    on_exit(fn ->
+      :file.del_dir_r(media_sources_directory)
+      Application.put_env(:jellyfish, :component_used?, file: false)
+    end)
 
     {:ok, %{media_sources_directory: media_sources_directory}}
   end

--- a/test/jellyfish_web/controllers/component/hls_component_test.exs
+++ b/test/jellyfish_web/controllers/component/hls_component_test.exs
@@ -21,6 +21,14 @@ defmodule JellyfishWeb.Component.HlsComponentTest do
                   }
                   |> map_keys_to_string()
 
+  setup_all do
+    Application.put_env(:jellyfish, :component_used?, hls: true)
+
+    on_exit(fn ->
+      Application.put_env(:jellyfish, :component_used?, hls: false)
+    end)
+  end
+
   describe "create hls component" do
     setup [:create_h264_room]
 

--- a/test/jellyfish_web/controllers/component/recording_component_test.exs
+++ b/test/jellyfish_web/controllers/component/recording_component_test.exs
@@ -15,6 +15,14 @@ defmodule JellyfishWeb.Component.RecordingComponentTest do
 
   @path_prefix "path_prefix"
 
+  setup_all do
+    Application.put_env(:jellyfish, :component_used?, recording: true)
+
+    on_exit(fn ->
+      Application.put_env(:jellyfish, :component_used?, recording: false)
+    end)
+  end
+
   describe "create recording component" do
     setup [:create_h264_room]
     setup :set_mox_from_context

--- a/test/jellyfish_web/controllers/component/rtsp_component_test.exs
+++ b/test/jellyfish_web/controllers/component/rtsp_component_test.exs
@@ -22,6 +22,14 @@ defmodule JellyfishWeb.Component.RTSPComponentTest do
   }
   @rtsp_custom_properties @rtsp_custom_options |> map_keys_to_string()
 
+  setup_all do
+    Application.put_env(:jellyfish, :component_used?, rtsp: true)
+
+    on_exit(fn ->
+      Application.put_env(:jellyfish, :component_used?, rtsp: false)
+    end)
+  end
+
   describe "create rtsp component" do
     setup [:create_h264_room]
 

--- a/test/jellyfish_web/controllers/component/sip_component_test.exs
+++ b/test/jellyfish_web/controllers/component/sip_component_test.exs
@@ -14,10 +14,12 @@ defmodule JellyfishWeb.Component.SIPComponentTest do
                           |> map_keys_to_string()
 
   setup_all do
-    Application.put_env(:jellyfish, :sip_config, sip_used?: true, sip_external_ip: "127.0.0.1")
+    Application.put_env(:jellyfish, :sip_config, sip_external_ip: "127.0.0.1")
+    Application.put_env(:jellyfish, :component_used?, sip: true)
 
     on_exit(fn ->
-      Application.put_env(:jellyfish, :sip_config, sip_used?: false, sip_external_ip: nil)
+      Application.put_env(:jellyfish, :sip_config, sip_external_ip: nil)
+      Application.put_env(:jellyfish, :component_used?, sip: false)
     end)
   end
 

--- a/test/jellyfish_web/controllers/component_controller_test.exs
+++ b/test/jellyfish_web/controllers/component_controller_test.exs
@@ -4,6 +4,14 @@ defmodule JellyfishWeb.ComponentControllerTest do
 
   @source_uri "rtsp://placeholder-19inrifjbsjb.it:12345/afwefae"
 
+  setup_all do
+    Application.put_env(:jellyfish, :component_used?, rtsp: true, hls: true)
+
+    on_exit(fn ->
+      Application.put_env(:jellyfish, :component_used?, rtsp: false, hls: false)
+    end)
+  end
+
   describe "create component" do
     test "renders errors when component type is invalid", %{conn: conn, room_id: room_id} do
       conn = post(conn, ~p"/room/#{room_id}/component", type: "invalid_type")

--- a/test/jellyfish_web/controllers/dial_controller_test.exs
+++ b/test/jellyfish_web/controllers/dial_controller_test.exs
@@ -10,10 +10,12 @@ defmodule JellyfishWeb.DialControllerTest do
   }
 
   setup_all do
-    Application.put_env(:jellyfish, :sip_config, sip_used?: true, sip_external_ip: "127.0.0.1")
+    Application.put_env(:jellyfish, :sip_config, sip_external_ip: "127.0.0.1")
+    Application.put_env(:jellyfish, :component_used?, sip: true, rtsp: true)
 
     on_exit(fn ->
-      Application.put_env(:jellyfish, :sip_config, sip_used?: false, sip_external_ip: nil)
+      Application.put_env(:jellyfish, :sip_config, sip_external_ip: nil)
+      Application.put_env(:jellyfish, :component_used?, sip: false, rtsp: false)
     end)
   end
 

--- a/test/jellyfish_web/controllers/subscription_controller_test.exs
+++ b/test/jellyfish_web/controllers/subscription_controller_test.exs
@@ -14,6 +14,16 @@ defmodule JellyfishWeb.SubscriptionControllerTest do
     password: "pass-word"
   }
 
+  setup_all do
+    Application.put_env(:jellyfish, :sip_config, sip_external_ip: "127.0.0.1")
+    Application.put_env(:jellyfish, :component_used?, sip: true, hls: true, recording: true)
+
+    on_exit(fn ->
+      Application.put_env(:jellyfish, :sip_config, sip_external_ip: nil)
+      Application.put_env(:jellyfish, :component_used?, sip: false, hls: false, recording: false)
+    end)
+  end
+
   setup %{conn: conn} do
     server_api_token = Application.fetch_env!(:jellyfish, :server_api_token)
     conn = put_req_header(conn, "authorization", "Bearer " <> server_api_token)
@@ -54,12 +64,6 @@ defmodule JellyfishWeb.SubscriptionControllerTest do
       conn: conn,
       room_id: room_id
     } do
-      Application.put_env(:jellyfish, :sip_config, sip_used?: true, sip_external_ip: "127.0.0.1")
-
-      on_exit(fn ->
-        Application.put_env(:jellyfish, :sip_config, sip_used?: false, sip_external_ip: nil)
-      end)
-
       conn =
         post(conn, ~p"/room/#{room_id}/component",
           type: "sip",

--- a/test/jellyfish_web/integration/server_notification_test.exs
+++ b/test/jellyfish_web/integration/server_notification_test.exs
@@ -93,10 +93,19 @@ defmodule JellyfishWeb.Integration.ServerNotificationTest do
   end
 
   setup_all do
-    Application.put_env(:jellyfish, :sip_config, sip_used?: true, sip_external_ip: "127.0.0.1")
+    Application.put_env(:jellyfish, :sip_config, sip_external_ip: "127.0.0.1")
+
+    Application.put_env(:jellyfish, :component_used?, sip: true, hls: true, rtsp: true, file: true)
 
     on_exit(fn ->
-      Application.put_env(:jellyfish, :sip_config, sip_used?: false, sip_external_ip: nil)
+      Application.put_env(:jellyfish, :sip_config, sip_external_ip: nil)
+
+      Application.put_env(:jellyfish, :component_used?,
+        sip: false,
+        hls: false,
+        rtsp: false,
+        file: false
+      )
     end)
 
     assert {:ok, _pid} = Endpoint.start_link()

--- a/test/jellyfish_web/integration/server_notification_test.exs
+++ b/test/jellyfish_web/integration/server_notification_test.exs
@@ -95,7 +95,12 @@ defmodule JellyfishWeb.Integration.ServerNotificationTest do
   setup_all do
     Application.put_env(:jellyfish, :sip_config, sip_external_ip: "127.0.0.1")
 
-    Application.put_env(:jellyfish, :component_used?, sip: true, hls: true, rtsp: true, file: true)
+    Application.put_env(:jellyfish, :component_used?,
+      sip: true,
+      hls: true,
+      rtsp: true,
+      file: true
+    )
 
     on_exit(fn ->
       Application.put_env(:jellyfish, :sip_config, sip_external_ip: nil)


### PR DESCRIPTION
This PR introduces a breaking change: users must now specify which components they wish to use using environment variables.

## Acknowledging the stipulations set forth:
 - [ ] I hereby confirm that a Pull Request involving updates to the Software Development Kit (SDK) has been smoothly merged, currently awaits processing, or is otherwise deemed unnecessary in this context.
 - [ ] I also affirm that another Pull Request, specifically addressing updates to the documentation body (commonly referred to as 'docs'), has either been successfully incorporated, is in the process of review, or is considered superfluous under the prevailing circumstances.
